### PR TITLE
Backport changes from Fedora/RHEL flavors:

### DIFF
--- a/pipeline/build-rpm-package.yaml
+++ b/pipeline/build-rpm-package.yaml
@@ -96,7 +96,7 @@ spec:
       type: string
     - name: ociStorage
       description: |
-        Quay.io namespace where the pipeline stores trusted artifacts, including
+        OCI registry URL where the pipeline stores trusted artifacts, including
         both resulting artifacts and intermediary by-products.
       default: quay.io/redhat-user-workloads/$(context.taskRun.namespace)/$(params.package-name)
 

--- a/task/calculate-deps.yaml
+++ b/task/calculate-deps.yaml
@@ -86,7 +86,7 @@ spec:
 
         if [ "$SSH_HOST" == "localhost" ] ; then
           echo "Running at local host is not supported"
-          return -1
+          exit 1
         fi
 
         workdir=/var/workdir
@@ -124,7 +124,7 @@ spec:
 
         # display dnf logs (no matter the mock exit status), and propagate the
         # mock failure (terminates the whole script)
-        remote_cmd tar xfO $HOMEDIR/results/chroot_scan.tar.gz
+        remote_cmd "tar xvfO '$HOMEDIR'/results/chroot_scan.tar.gz 2>&1 | cat"
         $success
 
         remote_cmd podman run -v "$HOMEDIR/results:/results" \

--- a/task/check-noarch.yaml
+++ b/task/check-noarch.yaml
@@ -54,7 +54,6 @@ spec:
       script: |
         #!/bin/bash
         set -x
-        
         python3 /usr/local/bin/check_noarch.py --results-dir /var/workdir/results
   volumes:
     - name: workdir

--- a/task/get-rpm-sources.yaml
+++ b/task/get-rpm-sources.yaml
@@ -98,7 +98,7 @@ spec:
       script: |
         #!/bin/bash
         set -x
-        
+
         if $(params.hermetic); then
           python3 /usr/local/bin/select_architectures.py "$@" --hermetic --results-file "$(results.skip-mpc-tasks.path)"
         else

--- a/task/import-to-quay.yaml
+++ b/task/import-to-quay.yaml
@@ -170,7 +170,6 @@ spec:
       script: |
         #!/bin/bash
         set -x
-        
         python3 /usr/local/bin/merge_syft_sbom.py --sbom-spdx sbom-spdx.json --syft-sbom syft-sbom.json --sbom-merged sbom-merged.json
     - name: show-sbom
       image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14

--- a/task/rpmbuild.yaml
+++ b/task/rpmbuild.yaml
@@ -104,7 +104,7 @@ spec:
 
         if [ "$SSH_HOST" == "localhost" ] ; then
           echo "Running at local host is not supported"
-          return -1
+          exit 1
         fi
 
         workdir=/var/workdir


### PR DESCRIPTION
- Address comments and whitespaces.
- Replace return -1 with exit, especially when it's not in a function.
- Ensure that tar for `chroot_scan.tar.gz` prints extracted filenames and that stderr and stdout are not interleaved.