### PR TITLE
feat: support nested specfiles

### DIFF
--- a/pipeline/build-rpm-package.yaml
+++ b/pipeline/build-rpm-package.yaml
@@ -75,6 +75,11 @@ spec:
       description: Execute the build with network isolation
       name: hermetic
       type: string
+    - default: .
+      description: Path to the source code of an application's component from where
+        to build rpm.
+      name: path-context
+      type: string
     - name: self-ref-url
       description: |
         Testing-only.  This must be filled as parameter in tests so we can point
@@ -240,6 +245,8 @@ spec:
           value: $(params.script-environment-image)
         - name: hermetic
           value: $(params.hermetic)
+        - name: context
+          value: $(params.path-context)
         - name: build-architectures
           value: ["$(params.build-architectures[*])"]
     - name: calculate-deps-x86-64

--- a/task/process-sources.yaml
+++ b/task/process-sources.yaml
@@ -33,6 +33,10 @@ spec:
     - description: Is the build hermetic?
       name: hermetic
       type: string
+    - name: context
+      description: Path to the directory to use as context.
+      type: string
+      default: .
     - description: List of architectures we build RPMs for
       name: build-architectures
       type: array
@@ -85,6 +89,9 @@ spec:
     volumeMounts:
       - mountPath: /var/workdir
         name: workdir
+    env:
+      - name: CONTEXT
+        value: $(params.context)
   steps:
     - name: use-trusted-artifact
       image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:9b180776a41d9a22a1c51539f1647c60defbbd55b44bbebdd4130e33512d8b0d
@@ -95,7 +102,7 @@ spec:
       image: $(params.script-environment-image)
       script: |
         set -ex
-        cd "/var/workdir/source"
+        cd "/var/workdir/source/${CONTEXT}"
 
         if test "$(params.specfile)" != "null" ; then
           specfile_name=$(params.specfile)
@@ -107,6 +114,8 @@ spec:
         dist-git-client --forked-from https://src.fedoraproject.org/rpms/$(params.package-name) sources
         # Make sure we use norpm: https://github.com/fedora-infra/rpmautospec/pull/319
         rpmautospec process-distgit "$specfile_name" "$specfile_name"
+
+        cd "/var/workdir/source"
         git diff
         # We remove the .git repository here to ensure that historical code does
         # not affect the output of the build.  This is critical because the user
@@ -120,6 +129,8 @@ spec:
       script: |
         #!/bin/bash
         set -x
+        working_dir="/var/workdir/source/${CONTEXT}"
+        cd "${working_dir}"
 
         if $(params.hermetic); then
           python3 /usr/local/bin/select_architectures.py "$@" --hermetic --results-file "$(results.skip-mpc-tasks.path)"
@@ -132,7 +143,7 @@ spec:
         - create
         - --store
         - $(params.ociStorage)
-        - $(results.dependencies-artifact.path)=/var/workdir/source
+        - $(results.dependencies-artifact.path)=/var/workdir/source/$(params.context)
       env:
         - name: IMAGE_EXPIRES_AFTER
           value: $(params.ociArtifactExpiresAfter)


### PR DESCRIPTION
- in project **Hummingbird**, rpms are located in a monorepo.
- as such, we need to be able to support building rpms with spec files located in sub folders.
- This PR adds a new param to the pipeline: `path-context` with a default of `.`