### PR TITLE
specify mock config from source

### DIFF
--- a/.tekton/monorepo-mock-config-pull-request.yaml
+++ b/.tekton/monorepo-mock-config-pull-request.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/konflux-ci/rpmbuild-pipeline?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: pipelines
+    appstudio.openshift.io/component: ci-for-pipeline
+    pipelines.appstudio.openshift.io/type: build
+  name: ci-for-pipeline-on-pull-request-monorepo-mock-config
+  namespace: rpm-build-pipeline-tenant
+spec:
+  params:
+    - name: package-name
+      value: "hello"
+    - name: git-url
+      value: "https://github.com/konflux-ci/rpmbuild-pipeline-monorepo-mock-config-test.git"
+    - name: revision
+      value: "main"
+    - name: target-branch
+      value: "main"
+    - name: self-ref-revision
+      value: "{{ revision }}"
+    - name: self-ref-url
+      value: "{{ source_url }}"
+    - name: test-suffix
+      value: -rpmbuild-pipeline
+    - name: ociStorage
+      value: quay.io/redhat-user-workloads/rpm-build-pipeline-tenant/ci-for-pipeline:on-pr-monorepo-mock-config-{{ revision }}
+    - name: build-architectures
+      value:
+        - x86_64
+    - name: specfile
+      value: "hello.spec"
+    - name: monorepo-subdir
+      value: "rpms/hello"
+    - name: mock-config-template-file
+      value: "mock/mock.cfg"
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: "{{ source_url }}"
+      - name: revision
+        value: "{{ revision }}"
+      - name: pathInRepo
+        value: pipeline/build-rpm-package.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ci-for-pipeline
+  workspaces:
+    - name: git-auth
+      secret:
+        secretName: '{{ git_auth_secret }}'

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -13,6 +13,7 @@ Below is the set of supported parameters accepted by the pipeline.
 | hermetic            | Perform the RPM build in a hermetic (offline) environment.                           | true                                |
 | mock-image          | Mock Container image used to perform RPM builds in the pipeline.                     | Check the [main branch][mock-image] |
 | specfile            | Specfile name. Default is null and package-name.spec is used.                        | null                                |
+| monorepo-subdir      | Path to the RPM .spec file within the source tree. Relative to repo root. If a directory is provided, the `specfile` will be resolved within it. | "."                                |
 
 
 ## Parametrizing timeouts

--- a/pipeline/build-rpm-package.yaml
+++ b/pipeline/build-rpm-package.yaml
@@ -75,6 +75,10 @@ spec:
       description: Execute the build with network isolation
       name: hermetic
       type: string
+    - default: .
+      description: Subdirectory of the source directory where the spec file is located. Needed for monorepos.
+      name: monorepo-subdir
+      type: string
     - name: self-ref-url
       description: |
         Testing-only.  This must be filled as parameter in tests so we can point
@@ -105,7 +109,10 @@ spec:
       name: specfile
       type: string
       default: "null"
-
+    - description: Location of the Mock configuration template file in source tree
+      name: mock-config-template-file
+      type: string
+      default: ""
     # This part is commented out because the parameter is not usable.  We don't
     # seem to be able to pass the given parameter down to override
     # `spec.tasks.{taskname}.timeout` defaults.  That's why we hardcode (for
@@ -240,11 +247,32 @@ spec:
           value: $(params.script-environment-image)
         - name: hermetic
           value: $(params.hermetic)
+        - name: monorepo-subdir
+          value: $(params.monorepo-subdir)
         - name: build-architectures
           value: ["$(params.build-architectures[*])"]
-    - name: calculate-deps-x86-64
+    - name: generate-mock-config
       runAfter:
         - process-sources
+      params:
+        - name: mock-config-template-file
+          value: $(params.mock-config-template-file)
+        - name: script-environment-image
+          value: $(params.script-environment-image)
+        - name: source-artifact
+          value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: $(params.self-ref-url)
+          - name: revision
+            value: $(params.self-ref-revision)
+          - name: pathInRepo
+            value: task/generate-mock-config.yaml
+    - name: calculate-deps-x86-64
+      runAfter:
+        - generate-mock-config
       params:
         - name: package-name
           value: $(params.package-name)
@@ -252,6 +280,8 @@ spec:
           value: $(params.target-branch)
         - name: koji-target
           value: $(params.koji-target)
+        - name: mock-config-template-file-content
+          value: $(tasks.generate-mock-config.results.mock-config-template-file-content)
         - name: PLATFORM
           value: $(tasks.process-sources.results.skip-mpc-tasks.deps-x86_64)
         - name: script-environment-image
@@ -311,7 +341,7 @@ spec:
             value: task/rpmbuild.yaml
     - name: calculate-deps-aarch64
       runAfter:
-        - process-sources
+        - generate-mock-config
       params:
         - name: package-name
           value: $(params.package-name)
@@ -319,6 +349,8 @@ spec:
           value: $(params.target-branch)
         - name: koji-target
           value: $(params.koji-target)
+        - name: mock-config-template-file-content
+          value: $(tasks.generate-mock-config.results.mock-config-template-file-content)
         - name: PLATFORM
           value: $(tasks.process-sources.results.skip-mpc-tasks.deps-aarch64)
         - name: script-environment-image
@@ -378,7 +410,7 @@ spec:
             value: task/rpmbuild.yaml
     - name: calculate-deps-s390x
       runAfter:
-        - process-sources
+        - generate-mock-config
       params:
         - name: package-name
           value: $(params.package-name)
@@ -386,6 +418,8 @@ spec:
           value: $(params.target-branch)
         - name: koji-target
           value: $(params.koji-target)
+        - name: mock-config-template-file-content
+          value: $(tasks.generate-mock-config.results.mock-config-template-file-content)
         - name: PLATFORM
           value: $(tasks.process-sources.results.skip-mpc-tasks.deps-s390x)
         - name: script-environment-image
@@ -445,7 +479,7 @@ spec:
             value: task/rpmbuild.yaml
     - name: calculate-deps-ppc64le
       runAfter:
-        - process-sources
+        - generate-mock-config
       params:
         - name: package-name
           value: $(params.package-name)
@@ -453,6 +487,8 @@ spec:
           value: $(params.target-branch)
         - name: koji-target
           value: $(params.koji-target)
+        - name: mock-config-template-file-content
+          value: $(tasks.generate-mock-config.results.mock-config-template-file-content)
         - name: PLATFORM
           value: $(tasks.process-sources.results.skip-mpc-tasks.deps-ppc64le)
         - name: script-environment-image

--- a/task/calculate-deps.yaml
+++ b/task/calculate-deps.yaml
@@ -25,6 +25,10 @@ spec:
       name: koji-target
       type: string
       default: DEFAULT
+    - description: Mock configuration file template content
+      name: mock-config-template-file-content
+      type: string
+      default: ""
     - description: RPM Build environment OCI image to run scripts in
       name: script-environment-image
       type: string
@@ -99,9 +103,28 @@ spec:
         remote_cmd echo "Hello from the other side!"
 
         # Allow mockbuilder (group mock) to read sources, and write results
-        remote_cmd mkdir "$HOMEDIR/results" "$HOMEDIR/source"
+        remote_cmd mkdir "$HOMEDIR/results" "$HOMEDIR/source" "$HOMEDIR/config"
         remote_cmd podman unshare setfacl -m g:135:r-x -m default:g:135:r-x "$HOMEDIR/source"
         remote_cmd podman unshare setfacl -m g:135:rwx -m default:g:135:rwx "$HOMEDIR/results"
+        remote_cmd podman unshare setfacl -m g:135:r-x -m default:g:135:r-x "$HOMEDIR/config"
+
+        VOLUME_MOUNTS=(
+          -v "$HOMEDIR/source:/source"
+          -v "$HOMEDIR/results:/results"
+        )
+
+        ROOT_CONFIG="fedora-rawhide-${arch}"
+        if [ -n "${MOCK_CONFIG_TEMPLATE_FILE}" ]; then
+          mkdir -p "$workdir/config"
+          VOLUME_MOUNTS+=(-v "$HOMEDIR/config:/config")
+
+          cat <<EOF | sed "s|@ARCH@|$arch|" | tee "$workdir/config/mock.cfg"
+        ${MOCK_CONFIG_TEMPLATE_FILE}
+        EOF
+
+          send "$workdir/config/mock.cfg" "$HOMEDIR/config/mock.cfg"
+          ROOT_CONFIG="/config/mock.cfg"
+        fi
 
         send "$workdir/source/" "$HOMEDIR/source"
 
@@ -114,7 +137,7 @@ spec:
             echo "Retrying in $sleep_time seconds."
             sleep $sleep_time
         done
- 
+
         if test "$(params.specfile)" != "null" ; then
           specfile_name=$(params.specfile)
         else
@@ -125,10 +148,9 @@ spec:
         success=true
         remote_cmd podman run -u mockbuilder \
                               -e KOJI_TARGET="$(params.koji-target)" \
-                              -v "$HOMEDIR/source:/source" \
-                              -v "$HOMEDIR/results:/results" \
+                              "${VOLUME_MOUNTS[@]}" \
                               --init --privileged --rm -ti "$mock_img" \
-            mock -r fedora-rawhide-"$arch" \
+            mock -r "$ROOT_CONFIG" \
                 --spec /source/$specfile_name \
                 --sources /source --resultdir /results \
                 --calculate-build-dependencies \
@@ -139,7 +161,10 @@ spec:
         remote_cmd "tar xvfO '$HOMEDIR'/results/chroot_scan.tar.gz 2>&1 | cat"
         $success
 
-        remote_cmd podman run -v "$HOMEDIR/results:/results" \
+        VOLUME_MOUNTS=(
+          -v "$HOMEDIR/results:/results"
+        )
+        remote_cmd podman run "${VOLUME_MOUNTS[@]}" \
                               --privileged --rm -ti "$mock_img" \
             mock-hermetic-repo \
             --lockfile /results/buildroot_lock.json \
@@ -151,6 +176,9 @@ spec:
         receive "$HOMEDIR/results/buildroot_lock.json" "$resultdir/buildroot_lock.json"
         receive "$HOMEDIR/results/buildroot_repo" "$resultdir"
         cat "$resultdir/buildroot_lock.json"
+      env:
+      - name: MOCK_CONFIG_TEMPLATE_FILE_CONTENT
+        value: "$(params.mock-config-template-file-content)"
       volumeMounts:
         - mountPath: /ssh
           name: ssh

--- a/task/generate-mock-config.yaml
+++ b/task/generate-mock-config.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  annotations:
+    tekton.dev/tags: rpm-build
+  name: generate-mock-config
+spec:
+  description: Generate Mock configuration template
+  params:
+    - description: File containing the Mock configuration template in source tree
+      name: mock-config-template-file
+      type: string
+    - description: RPM Build environment OCI image to run scripts in
+      name: script-environment-image
+      type: string
+    - description: The Trusted Artifact URI pointing to the artifact with the source code.
+      name: source-artifact
+      type: string
+  results:
+    - name: mock-config-template-file-content
+      type: string
+      description: Generated Mock configuration template (as a string)
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+  steps:
+    - name: use-trusted-artifact
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:9b180776a41d9a22a1c51539f1647c60defbbd55b44bbebdd4130e33512d8b0d
+      args:
+        - use
+        - $(params.source-artifact)=/var/workdir/source
+    - name: generate-mock-config
+      image: $(params.script-environment-image)
+      script: |
+        #!/bin/bash
+        set -ex
+        set -o pipefail
+
+        if [ -n "$(params.mock-config-template-file)" ]; then
+          configFile="/var/workdir/source/$(params.mock-config-template-file)"
+          if [ -f "$configFile" ]; then
+            echo "Using Mock configuration template file: $configFile"
+            cat "$configFile" > "$(results.mock-config-template-file-content.path)"
+          else
+            echo "Mock configuration template file not found: $configFile"
+            exit 1
+          fi
+        else
+          echo "Mock configuration template file not specified"
+          echo -n "" > "$(results.mock-config-template-file-content.path)"
+        fi
+  volumes:
+    - name: workdir
+      emptyDir: {}

--- a/task/process-sources.yaml
+++ b/task/process-sources.yaml
@@ -33,6 +33,9 @@ spec:
     - description: Is the build hermetic?
       name: hermetic
       type: string
+    - name: monorepo-subdir
+      description: Subdirectory of the source directory where the spec file is located.
+      type: string
     - description: List of architectures we build RPMs for
       name: build-architectures
       type: array
@@ -85,6 +88,9 @@ spec:
     volumeMounts:
       - mountPath: /var/workdir
         name: workdir
+    env:
+      - name: MONOREPO_SUBDIR
+        value: $(params.monorepo-subdir)
   steps:
     - name: use-trusted-artifact
       image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:9b180776a41d9a22a1c51539f1647c60defbbd55b44bbebdd4130e33512d8b0d
@@ -95,7 +101,7 @@ spec:
       image: $(params.script-environment-image)
       script: |
         set -ex
-        cd "/var/workdir/source"
+        cd "/var/workdir/source/${MONOREPO_SUBDIR}"
 
         if test "$(params.specfile)" != "null" ; then
           specfile_name=$(params.specfile)
@@ -106,7 +112,13 @@ spec:
 
         dist-git-client --forked-from https://src.fedoraproject.org/rpms/$(params.package-name) sources
         # Make sure we use norpm: https://github.com/fedora-infra/rpmautospec/pull/319
-        rpmautospec process-distgit "$specfile_name" "$specfile_name"
+        if [ "${MONOREPO_SUBDIR:-.}" = "." ]; then
+          rpmautospec process-distgit "$specfile_name" "$specfile_name"
+        else
+          echo "'rpmautospec process-distgit' is not supported for monorepos"
+        fi
+
+        cd "/var/workdir/source"
         git diff
         # We remove the .git repository here to ensure that historical code does
         # not affect the output of the build.  This is critical because the user
@@ -120,11 +132,13 @@ spec:
       script: |
         #!/bin/bash
         set -x
+        working_dir="/var/workdir/source/${MONOREPO_SUBDIR}"
+        cd "${working_dir}"
 
         if $(params.hermetic); then
-          python3 /usr/local/bin/select_architectures.py "$@" --hermetic --results-file "$(results.skip-mpc-tasks.path)"
+          python3 /usr/local/bin/select_architectures.py "$@" --hermetic --results-file "$(results.skip-mpc-tasks.path)" --workdir "${working_dir}"
         else
-          python3 /usr/local/bin/select_architectures.py "$@" --results-file "$(results.skip-mpc-tasks.path)"
+          python3 /usr/local/bin/select_architectures.py "$@" --results-file "$(results.skip-mpc-tasks.path)" --workdir "${working_dir}"
         fi
     - name: create-trusted-artifact
       image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:9b180776a41d9a22a1c51539f1647c60defbbd55b44bbebdd4130e33512d8b0d
@@ -132,7 +146,9 @@ spec:
         - create
         - --store
         - $(params.ociStorage)
-        - $(results.dependencies-artifact.path)=/var/workdir/source
+        # when dealing with monorepos, we only are interested in the sources for the spec file, not the entire monorepo.
+        # therefore we need to copy the sources for the spec file to the dependencies artifact.
+        - $(results.dependencies-artifact.path)=/var/workdir/source/$(params.monorepo-subdir)
       env:
         - name: IMAGE_EXPIRES_AFTER
           value: $(params.ociArtifactExpiresAfter)


### PR DESCRIPTION
- in project Hummingbird, rpms are located in a monorepo.
- Resolve RPM spec path with explicit context so nested or non-root specs are handled consistently
- Add `working_dir` parameter to `select_architectures.py` to decouple from CWD and support Tekton workspaces
- Generate and use `mock` configuration from the repository source (when present), falling back to default mock config otherwise
- Wire new parameters through Tekton tasks/pipeline so `generate-mock-config`, `process-sources`, and `rpmbuild` can consume spec path and working directory
- Improve build reproducibility and local/CI parity by keeping mock settings versioned with sources
- Backwards compatible: behavior remains unchanged if no source-provided mock config is found
- Minor refactors and clarifications around path handling