### PR TITLE
feat: refactor mock config templating

### DIFF
--- a/.tekton/monorepo-mock-config-pull-request-non-hermetic.yaml
+++ b/.tekton/monorepo-mock-config-pull-request-non-hermetic.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/konflux-ci/rpmbuild-pipeline?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: pipelines
+    appstudio.openshift.io/component: ci-for-pipeline
+    pipelines.appstudio.openshift.io/type: build
+  name: ci-for-pipeline-on-pull-request-monorepo-mock-config-non-hermetic
+  namespace: rpm-build-pipeline-tenant
+spec:
+  params:
+    - name: package-name
+      value: "hello"
+    - name: git-url
+      value: "https://github.com/konflux-ci/rpmbuild-pipeline-monorepo-mock-config-test.git"
+    - name: revision
+      value: "main"
+    - name: target-branch
+      value: "main"
+    - name: self-ref-revision
+      value: "{{ revision }}"
+    - name: self-ref-url
+      value: "{{ source_url }}"
+    - name: test-suffix
+      value: -rpmbuild-pipeline
+    - name: ociStorage
+      value: quay.io/redhat-user-workloads/rpm-build-pipeline-tenant/ci-for-pipeline:on-pr-monorepo-mock-config-{{ revision }}
+    - name: build-architectures
+      value:
+        - x86_64
+    - name: specfile
+      value: "hello.spec"
+    - name: monorepo-subdir
+      value: "rpms/hello"
+    - name: mock-config-template-file
+      value: "mock/mock.cfg"
+      # This is a non-hermetic build, so we can test passing
+      #the mock config template file as a parameter.
+    - name: hermetic
+      value: "false"
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: "{{ source_url }}"
+      - name: revision
+        value: "{{ revision }}"
+      - name: pathInRepo
+        value: pipeline/build-rpm-package.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ci-for-pipeline
+  workspaces:
+    - name: git-auth
+      secret:
+        secretName: '{{ git_auth_secret }}'

--- a/pipeline/build-rpm-package.yaml
+++ b/pipeline/build-rpm-package.yaml
@@ -251,28 +251,11 @@ spec:
           value: $(params.monorepo-subdir)
         - name: build-architectures
           value: ["$(params.build-architectures[*])"]
-    - name: generate-mock-config
-      runAfter:
-        - process-sources
-      params:
         - name: mock-config-template-file
           value: $(params.mock-config-template-file)
-        - name: script-environment-image
-          value: $(params.script-environment-image)
-        - name: source-artifact
-          value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
-      taskRef:
-        resolver: git
-        params:
-          - name: url
-            value: $(params.self-ref-url)
-          - name: revision
-            value: $(params.self-ref-revision)
-          - name: pathInRepo
-            value: task/generate-mock-config.yaml
     - name: calculate-deps-x86-64
       runAfter:
-        - generate-mock-config
+        - process-sources
       params:
         - name: package-name
           value: $(params.package-name)
@@ -280,14 +263,16 @@ spec:
           value: $(params.target-branch)
         - name: koji-target
           value: $(params.koji-target)
-        - name: mock-config-template-file-content
-          value: $(tasks.generate-mock-config.results.mock-config-template-file-content)
+        - name: mock-config-template-file
+          value: $(params.mock-config-template-file)
         - name: PLATFORM
           value: $(tasks.process-sources.results.skip-mpc-tasks.deps-x86_64)
         - name: script-environment-image
           value: $(params.script-environment-image)
         - name: dependencies-artifact
           value: $(tasks.process-sources.results.dependencies-artifact)
+        - name: mock-config-artifact
+          value: $(tasks.process-sources.results.mock-config-artifact)
         - name: ociStorage
           value: $(params.ociStorage).calculation-x86_64
         - name: ociArtifactExpiresAfter
@@ -324,6 +309,10 @@ spec:
           value: $(tasks.process-sources.results.dependencies-artifact)
         - name: calculation-artifact
           value: $(tasks.calculate-deps-x86-64.results.calculation-artifact)
+        - name: mock-config-template-file
+          value: $(params.mock-config-template-file)
+        - name: mock-config-artifact
+          value: $(tasks.process-sources.results.mock-config-artifact)
         - name: ociStorage
           value: $(params.ociStorage).rpmbuild-x86_64
         - name: ociArtifactExpiresAfter
@@ -341,7 +330,7 @@ spec:
             value: task/rpmbuild.yaml
     - name: calculate-deps-aarch64
       runAfter:
-        - generate-mock-config
+        - process-sources
       params:
         - name: package-name
           value: $(params.package-name)
@@ -349,14 +338,16 @@ spec:
           value: $(params.target-branch)
         - name: koji-target
           value: $(params.koji-target)
-        - name: mock-config-template-file-content
-          value: $(tasks.generate-mock-config.results.mock-config-template-file-content)
+        - name: mock-config-template-file
+          value: $(params.mock-config-template-file)
         - name: PLATFORM
           value: $(tasks.process-sources.results.skip-mpc-tasks.deps-aarch64)
         - name: script-environment-image
           value: $(params.script-environment-image)
         - name: dependencies-artifact
           value: $(tasks.process-sources.results.dependencies-artifact)
+        - name: mock-config-artifact
+          value: $(tasks.process-sources.results.mock-config-artifact)
         - name: ociStorage
           value: $(params.ociStorage).calculation-aarch64
         - name: ociArtifactExpiresAfter
@@ -393,6 +384,10 @@ spec:
           value: $(tasks.process-sources.results.dependencies-artifact)
         - name: calculation-artifact
           value: $(tasks.calculate-deps-aarch64.results.calculation-artifact)
+        - name: mock-config-template-file
+          value: $(params.mock-config-template-file)
+        - name: mock-config-artifact
+          value: $(tasks.process-sources.results.mock-config-artifact)
         - name: ociStorage
           value: $(params.ociStorage).rpmbuild-aarch64
         - name: ociArtifactExpiresAfter
@@ -410,7 +405,7 @@ spec:
             value: task/rpmbuild.yaml
     - name: calculate-deps-s390x
       runAfter:
-        - generate-mock-config
+        - process-sources
       params:
         - name: package-name
           value: $(params.package-name)
@@ -418,14 +413,16 @@ spec:
           value: $(params.target-branch)
         - name: koji-target
           value: $(params.koji-target)
-        - name: mock-config-template-file-content
-          value: $(tasks.generate-mock-config.results.mock-config-template-file-content)
+        - name: mock-config-template-file
+          value: $(params.mock-config-template-file)
         - name: PLATFORM
           value: $(tasks.process-sources.results.skip-mpc-tasks.deps-s390x)
         - name: script-environment-image
           value: $(params.script-environment-image)
         - name: dependencies-artifact
           value: $(tasks.process-sources.results.dependencies-artifact)
+        - name: mock-config-artifact
+          value: $(tasks.process-sources.results.mock-config-artifact)
         - name: ociStorage
           value: $(params.ociStorage).calculation-s390x
         - name: ociArtifactExpiresAfter
@@ -462,6 +459,10 @@ spec:
           value: $(tasks.process-sources.results.dependencies-artifact)
         - name: calculation-artifact
           value: $(tasks.calculate-deps-s390x.results.calculation-artifact)
+        - name: mock-config-template-file
+          value: $(params.mock-config-template-file)
+        - name: mock-config-artifact
+          value: $(tasks.process-sources.results.mock-config-artifact)
         - name: ociStorage
           value: $(params.ociStorage).rpmbuild-s390x
         - name: ociArtifactExpiresAfter
@@ -479,7 +480,7 @@ spec:
             value: task/rpmbuild.yaml
     - name: calculate-deps-ppc64le
       runAfter:
-        - generate-mock-config
+        - process-sources
       params:
         - name: package-name
           value: $(params.package-name)
@@ -487,14 +488,16 @@ spec:
           value: $(params.target-branch)
         - name: koji-target
           value: $(params.koji-target)
-        - name: mock-config-template-file-content
-          value: $(tasks.generate-mock-config.results.mock-config-template-file-content)
+        - name: mock-config-template-file
+          value: $(params.mock-config-template-file)
         - name: PLATFORM
           value: $(tasks.process-sources.results.skip-mpc-tasks.deps-ppc64le)
         - name: script-environment-image
           value: $(params.script-environment-image)
         - name: dependencies-artifact
           value: $(tasks.process-sources.results.dependencies-artifact)
+        - name: mock-config-artifact
+          value: $(tasks.process-sources.results.mock-config-artifact)
         - name: ociStorage
           value: $(params.ociStorage).calculation-ppc64le
         - name: ociArtifactExpiresAfter
@@ -531,6 +534,10 @@ spec:
           value: $(tasks.process-sources.results.dependencies-artifact)
         - name: calculation-artifact
           value: $(tasks.calculate-deps-ppc64le.results.calculation-artifact)
+        - name: mock-config-template-file
+          value: $(params.mock-config-template-file)
+        - name: mock-config-artifact
+          value: $(tasks.process-sources.results.mock-config-artifact)
         - name: ociStorage
           value: $(params.ociStorage).rpmbuild-ppc64le
         - name: ociArtifactExpiresAfter

--- a/task/calculate-deps.yaml
+++ b/task/calculate-deps.yaml
@@ -26,7 +26,7 @@ spec:
       type: string
       default: DEFAULT
     - description: Mock configuration file template content
-      name: mock-config-template-file-content
+      name: mock-config-template-file
       type: string
       default: ""
     - description: RPM Build environment OCI image to run scripts in
@@ -34,6 +34,9 @@ spec:
       type: string
     - description: The Trusted Artifact URI pointing to the artifact with the rpm deps and source.
       name: dependencies-artifact
+      type: string
+    - description: The Trusted Artifact URI pointing to the artifact with the mock configuration template.
+      name: mock-config-artifact
       type: string
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -57,6 +60,11 @@ spec:
       args:
         - use
         - $(params.dependencies-artifact)=/var/workdir/source
+    - name: use-trusted-artifact-mock-config
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:9b180776a41d9a22a1c51539f1647c60defbbd55b44bbebdd4130e33512d8b0d
+      args:
+        - use
+        - $(params.mock-config-artifact)=/var/workdir/mock-config
     - name: mock-build
       image: "quay.io/redhat-appstudio/multi-platform-runner:01c7670e81d5120347cf0ad13372742489985e5f@sha256:246adeaaba600e207131d63a7f706cffdcdc37d8f600c56187123ec62823ff44"
       script: |
@@ -103,27 +111,29 @@ spec:
         remote_cmd echo "Hello from the other side!"
 
         # Allow mockbuilder (group mock) to read sources, and write results
-        remote_cmd mkdir "$HOMEDIR/results" "$HOMEDIR/source" "$HOMEDIR/config"
+        remote_cmd mkdir "$HOMEDIR/results" "$HOMEDIR/source" "$HOMEDIR/mock-config"
         remote_cmd podman unshare setfacl -m g:135:r-x -m default:g:135:r-x "$HOMEDIR/source"
         remote_cmd podman unshare setfacl -m g:135:rwx -m default:g:135:rwx "$HOMEDIR/results"
-        remote_cmd podman unshare setfacl -m g:135:r-x -m default:g:135:r-x "$HOMEDIR/config"
+        remote_cmd podman unshare setfacl -m g:135:r-x -m default:g:135:r-x "$HOMEDIR/mock-config"
 
         VOLUME_MOUNTS=(
           -v "$HOMEDIR/source:/source"
           -v "$HOMEDIR/results:/results"
         )
+        mkdir -p "$workdir/mock-config"
 
         ROOT_CONFIG="fedora-rawhide-${arch}"
-        if [ -n "${MOCK_CONFIG_TEMPLATE_FILE}" ]; then
-          mkdir -p "$workdir/config"
-          VOLUME_MOUNTS+=(-v "$HOMEDIR/config:/config")
+        if [ -n "$(params.mock-config-template-file)" ]; then
+          mock_config_file="$workdir/mock-config/$(params.mock-config-template-file)"
+          sed -i "s|@ARCH@|$arch|" "$mock_config_file"
+          VOLUME_MOUNTS+=(-v "$HOMEDIR/mock-config:/mock-config")
+          # create the target directory in the mock-config directory
+          targetFile="$HOMEDIR/mock-config/$(params.mock-config-template-file)"
+          targetDir=$(dirname "$targetFile")
+          remote_cmd mkdir -p "$targetDir"
 
-          cat <<EOF | sed "s|@ARCH@|$arch|" | tee "$workdir/config/mock.cfg"
-        ${MOCK_CONFIG_TEMPLATE_FILE}
-        EOF
-
-          send "$workdir/config/mock.cfg" "$HOMEDIR/config/mock.cfg"
-          ROOT_CONFIG="/config/mock.cfg"
+          send "$mock_config_file" "$HOMEDIR/mock-config/$(params.mock-config-template-file)"
+          ROOT_CONFIG="/mock-config/$(params.mock-config-template-file)"
         fi
 
         send "$workdir/source/" "$HOMEDIR/source"
@@ -176,9 +186,6 @@ spec:
         receive "$HOMEDIR/results/buildroot_lock.json" "$resultdir/buildroot_lock.json"
         receive "$HOMEDIR/results/buildroot_repo" "$resultdir"
         cat "$resultdir/buildroot_lock.json"
-      env:
-      - name: MOCK_CONFIG_TEMPLATE_FILE_CONTENT
-        value: "$(params.mock-config-template-file-content)"
       volumeMounts:
         - mountPath: /ssh
           name: ssh

--- a/task/process-sources.yaml
+++ b/task/process-sources.yaml
@@ -36,12 +36,18 @@ spec:
     - name: monorepo-subdir
       description: Subdirectory of the source directory where the spec file is located.
       type: string
+    - description: File containing the Mock configuration template in source tree
+      name: mock-config-template-file
+      type: string
     - description: List of architectures we build RPMs for
       name: build-architectures
       type: array
   results:
     - name: dependencies-artifact
       description: The Trusted Artifact URI pointing to the artifact with the rpm deps and source.
+      type: string
+    - name: mock-config-artifact
+      description: The Trusted Artifact URI pointing to the artifact with the mock configuration template.
       type: string
     - name: skip-mpc-tasks
       description: |
@@ -119,6 +125,20 @@ spec:
         fi
 
         cd "/var/workdir/source"
+        mkdir -p "/var/workdir/mock-config"
+
+        if [ -n "$(params.mock-config-template-file)" ]; then
+          # copy the mock configuration template file to the mock-config directory,
+          # and a mock-config trusted artifact is created.
+          # the mock configuation template file name is then available for downstream tasks
+          configFile="/var/workdir/source/$(params.mock-config-template-file)"
+          targetFile="/var/workdir/mock-config/$(params.mock-config-template-file)"
+          targetDir=$(dirname "$targetFile")
+          mkdir -p "$targetDir"
+          echo "Copying Mock configuration template file: $configFile to $targetFile"
+          cp "$configFile" "$targetFile"
+        fi
+
         git diff
         # We remove the .git repository here to ensure that historical code does
         # not affect the output of the build.  This is critical because the user
@@ -149,6 +169,16 @@ spec:
         # when dealing with monorepos, we only are interested in the sources for the spec file, not the entire monorepo.
         # therefore we need to copy the sources for the spec file to the dependencies artifact.
         - $(results.dependencies-artifact.path)=/var/workdir/source/$(params.monorepo-subdir)
+      env:
+        - name: IMAGE_EXPIRES_AFTER
+          value: $(params.ociArtifactExpiresAfter)
+    - name: create-trusted-artifact-mock-config
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:9b180776a41d9a22a1c51539f1647c60defbbd55b44bbebdd4130e33512d8b0d
+      args:
+        - create
+        - --store
+        - $(params.ociStorage)
+        - $(results.mock-config-artifact.path)=/var/workdir/mock-config
       env:
         - name: IMAGE_EXPIRES_AFTER
           value: $(params.ociArtifactExpiresAfter)

--- a/task/rpmbuild.yaml
+++ b/task/rpmbuild.yaml
@@ -49,6 +49,13 @@ spec:
         Name of specfile when specfile doesn't have the same prefix name as package name.
         Default is null and package-name.spec is used.
       type: string
+    - description: Mock configuration file template content
+      name: mock-config-template-file
+      type: string
+      default: ""
+    - description: The Trusted Artifact URI pointing to the artifact with the mock configuration template.
+      name: mock-config-artifact
+      type: string
   results:
     - name: rpmbuild-artifact
       description: The Trusted Artifact URI pointing to the artifact with the result of the build.
@@ -71,6 +78,11 @@ spec:
       args:
         - use
         - $(params.calculation-artifact)=/var/workdir/results
+    - name: use-trusted-artifact-mock-config
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:9b180776a41d9a22a1c51539f1647c60defbbd55b44bbebdd4130e33512d8b0d
+      args:
+        - use
+        - $(params.mock-config-artifact)=/var/workdir/mock-config
     - name: mock-build
       image: "quay.io/redhat-appstudio/multi-platform-runner:01c7670e81d5120347cf0ad13372742489985e5f@sha256:246adeaaba600e207131d63a7f706cffdcdc37d8f600c56187123ec62823ff44"
       script: |
@@ -117,11 +129,12 @@ spec:
         remote_cmd echo "Hello from the other side!"
 
         # Allow mockbuilder (group mock) to read sources, and write results
-        remote_cmd mkdir "$HOMEDIR/results" "$HOMEDIR/source" "$HOMEDIR/var_lib_mock"
+        remote_cmd mkdir "$HOMEDIR/results" "$HOMEDIR/source" "$HOMEDIR/var_lib_mock" "$HOMEDIR/mock-config"
         remote_cmd podman unshare setfacl -m g:135:r-x -m default:g:135:r-x "$HOMEDIR/source"
         remote_cmd podman unshare setfacl -m g:135:rwx -m default:g:135:rwx "$HOMEDIR/results"
         remote_cmd podman unshare chgrp 135 "$HOMEDIR/var_lib_mock"
         remote_cmd podman unshare chmod g+rwx "$HOMEDIR/var_lib_mock"
+        remote_cmd podman unshare setfacl -m g:135:r-x -m default:g:135:r-x "$HOMEDIR/mock-config"
 
         send "$workdir/source/" "$HOMEDIR/source"
 
@@ -148,6 +161,20 @@ spec:
             --security-opt label=disable "$mock_img"
         )
 
+        ROOT_CONFIG="fedora-rawhide-${arch}"
+        if [ -n "$(params.mock-config-template-file)" ]; then
+          mock_config_file="$workdir/mock-config/$(params.mock-config-template-file)"
+          sed -i "s|@ARCH@|$arch|" "$mock_config_file"
+          podman_params=(-v "$HOMEDIR/mock-config:/mock-config" "${podman_params[@]}")
+          # create the target directory in the mock-config directory
+          targetFile="$HOMEDIR/mock-config/$(params.mock-config-template-file)"
+          targetDir=$(dirname "$targetFile")
+          remote_cmd mkdir -p "$targetDir"
+
+          send "$mock_config_file" "$HOMEDIR/mock-config/$(params.mock-config-template-file)"
+          ROOT_CONFIG="/mock-config/$(params.mock-config-template-file)"
+        fi
+
         if test "$(params.specfile)" != "null" ; then
           specfile_name=$(params.specfile)
         else
@@ -157,7 +184,9 @@ spec:
 
         success=true
         if "$(params.hermetic)"; then
-
+          if [ -n "$(params.mock-config-template-file)" ]; then
+            echo "Warning: mock-config-template-file was provided but will be ignored for hermetic builds." >&2
+          fi
           # Give mockbuilder rights to consume buildroot.
           remote_cmd mkdir "$HOMEDIR/buildroot"
           remote_cmd podman unshare setfacl -m g:135:r-x -m default:g:135:r-x "$HOMEDIR/buildroot"
@@ -175,7 +204,7 @@ spec:
         else
           remote_cmd podman run -e KOJI_TARGET="$(params.koji-target)" \
                                 "${podman_params[@]}" \
-              mock -r fedora-rawhide-"$arch" \
+              mock -r "$ROOT_CONFIG" \
                   --spec /source/$specfile_name \
                   --sources /source --resultdir /results \
           || success=false


### PR DESCRIPTION
- this PR adds the use of a separate trusted artifact that contains
  the mock-config template file to be passed to downstream
  tasks.
- this ensure that the source trusted artifact only ever contains
  the "source"
- mock config template should be used for rpmbuild
  - in the event that the build is non-hermetic, we may want to use
    a mock config template.
  - add a test for this case.