### PR TITLE
All tasks respect ociArtifactExpiresAfter and create ociArtifactExpir…

### DIFF
--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -15,6 +15,7 @@ Below is the set of supported parameters accepted by the pipeline.
 | specfile            | Specfile name. Default is null and package-name.spec is used.                        | null                                |
 | monorepo-subdir      | Path to the RPM .spec file within the source tree. Relative to repo root. If a directory is provided, the `specfile` will be resolved within it. | "."                                |
 | mock-config-template-filename-in-sources | If Mock Config template exists within source directory, specify where. | "" |
+| ociArtifactExpiresAfter | How long Trusted Artifacts should be retained                                    | ""                                  |
 
 ## Parametrizing timeouts
 

--- a/pipeline/build-rpm-package.yaml
+++ b/pipeline/build-rpm-package.yaml
@@ -109,6 +109,10 @@ spec:
       name: specfile
       type: string
       default: "null"
+    - description: How long Trusted Artifacts should be retained
+      type: string
+      name: ociArtifactExpiresAfter
+      default: ""
     # This part is commented out because the parameter is not usable.  We don't
     # seem to be able to pass the given parameter down to override
     # `spec.tasks.{taskname}.timeout` defaults.  That's why we hardcode (for
@@ -198,7 +202,7 @@ spec:
         - name: ociStorage
           value: $(params.ociStorage).git
         - name: ociArtifactExpiresAfter
-          value: 14d
+          value: $(params.ociArtifactExpiresAfter)
       runAfter:
         - init
       taskRef:
@@ -225,7 +229,7 @@ spec:
           - name: pathInRepo
             value: task/process-sources.yaml
           - name: ociArtifactExpiresAfter
-            value: 14d
+            value: $(params.ociArtifactExpiresAfter)
       runAfter:
         - clone-repository
       params:
@@ -238,7 +242,7 @@ spec:
         - name: ociStorage
           value: $(params.ociStorage).rpm-sources
         - name: ociArtifactExpiresAfter
-          value: 14d
+          value: $(params.ociArtifactExpiresAfter)
         - name: script-environment-image
           value: $(params.script-environment-image)
         - name: hermetic
@@ -272,7 +276,7 @@ spec:
         - name: chroot
           value: fedora-rawhide-@ARCH@
         - name: ociArtifactExpiresAfter
-          value: 14d
+          value: $(params.ociArtifactExpiresAfter)
     - name: calculate-deps-x86-64
       runAfter:
         - process-sources
@@ -293,7 +297,7 @@ spec:
         - name: ociStorage
           value: $(params.ociStorage).calculation-x86_64
         - name: ociArtifactExpiresAfter
-          value: 14d
+          value: $(params.ociArtifactExpiresAfter)
         - name: specfile
           value: $(params.specfile)
       taskRef:
@@ -329,7 +333,7 @@ spec:
         - name: ociStorage
           value: $(params.ociStorage).rpmbuild-x86_64
         - name: ociArtifactExpiresAfter
-          value: 14d
+          value: $(params.ociArtifactExpiresAfter)
         - name: specfile
           value: $(params.specfile)
       taskRef:
@@ -361,7 +365,7 @@ spec:
         - name: ociStorage
           value: $(params.ociStorage).calculation-aarch64
         - name: ociArtifactExpiresAfter
-          value: 14d
+          value: $(params.ociArtifactExpiresAfter)
         - name: specfile
           value: $(params.specfile)
       taskRef:
@@ -397,7 +401,7 @@ spec:
         - name: ociStorage
           value: $(params.ociStorage).rpmbuild-aarch64
         - name: ociArtifactExpiresAfter
-          value: 14d
+          value: $(params.ociArtifactExpiresAfter)
         - name: specfile
           value: $(params.specfile)
       taskRef:
@@ -429,7 +433,7 @@ spec:
         - name: ociStorage
           value: $(params.ociStorage).calculation-s390x
         - name: ociArtifactExpiresAfter
-          value: 14d
+          value: $(params.ociArtifactExpiresAfter)
         - name: specfile
           value: $(params.specfile)
       taskRef:
@@ -465,7 +469,7 @@ spec:
         - name: ociStorage
           value: $(params.ociStorage).rpmbuild-s390x
         - name: ociArtifactExpiresAfter
-          value: 14d
+          value: $(params.ociArtifactExpiresAfter)
         - name: specfile
           value: $(params.specfile)
       taskRef:
@@ -497,7 +501,7 @@ spec:
         - name: ociStorage
           value: $(params.ociStorage).calculation-ppc64le
         - name: ociArtifactExpiresAfter
-          value: 14d
+          value: $(params.ociArtifactExpiresAfter)
         - name: specfile
           value: $(params.specfile)
       taskRef:
@@ -533,7 +537,7 @@ spec:
         - name: ociStorage
           value: $(params.ociStorage).rpmbuild-ppc64le
         - name: ociArtifactExpiresAfter
-          value: 14d
+          value: $(params.ociArtifactExpiresAfter)
         - name: specfile
           value: $(params.specfile)
       taskRef:

--- a/task/calculate-deps.yaml
+++ b/task/calculate-deps.yaml
@@ -33,6 +33,9 @@ spec:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
       type: string
+    - name: ociArtifactExpiresAfter
+      description: How long Trusted Artifacts should be retained
+      type: string
     - name: specfile
       description: |
         Name of specfile when specfile doesn't have the same prefix name as package name.
@@ -173,6 +176,9 @@ spec:
         - --store
         - $(params.ociStorage)
         - $(results.calculation-artifact.path)=/var/workdir/results
+      env:
+        - name: IMAGE_EXPIRES_AFTER
+          value: $(params.ociArtifactExpiresAfter)
   volumes:
     - name: ssh
       secret:


### PR DESCRIPTION
…esAfter as global variable

Fixes: https://github.com/konflux-ci/rpmbuild-pipeline/issues/117