### PR TITLE
fix placement of params.build-platforms

### DIFF
--- a/pipeline/build-rpm-package.yaml
+++ b/pipeline/build-rpm-package.yaml
@@ -261,6 +261,8 @@ spec:
           value: $(params.monorepo-subdir)
         - name: build-architectures
           value: ["$(params.build-architectures[*])"]
+        - name: build-platforms
+          value: ["$(params.build-platforms[*])"]
     - name: prepare-mock-config
       retries: 3
       taskRef:
@@ -287,8 +289,6 @@ spec:
           value: fedora-rawhide-@ARCH@
         - name: ociArtifactExpiresAfter
           value: $(params.ociArtifactExpiresAfter)
-        - name: build-platforms
-          value: ["$(params.build-platforms[*])"]
     - name: calculate-deps-x86-64
       runAfter:
         - process-sources


### PR DESCRIPTION
- params.build-platforms should be passed into `process-sources` and not `prepare-mock-config`