### PR TITLE
import-to-quay: silence "no such file" warnings from tar

### DIFF
--- a/task/import-to-quay.yaml
+++ b/task/import-to-quay.yaml
@@ -141,7 +141,7 @@ spec:
         # of the Syft tooling (which likely performs all kinds of other
         # heuristics, in a legitimate way).
 
-        set +x
+        set -x
         # expects to parse all srpm files in /mnt
         # writes output to /mnt/syft-sbom.json
         SRCDIR=$(pwd)


### PR DESCRIPTION
Silence these warnings:

    tar: *.tg*: Cannot open: No such file or directory
    tar: Error is not recoverable: exiting now

These warnings are benign because we do not have 'set -e' configured, and the script pipeline fails for other reasons (the last command of the script is 'true').

However, to avoid confusion, it is better to instruct the shell not to iterate over non-existent files.

Relates: #129