### PR TITLE
Normalize NVR for OCI tag compatibility in import-to-quay

### DIFF
--- a/task/import-to-quay.yaml
+++ b/task/import-to-quay.yaml
@@ -111,7 +111,11 @@ spec:
 
         # Get NVR from any SRPM
         NVR=$(<nvr.log)
-        IMAGE_URL="$(params.ociStorage).nvr-$NVR"
+
+        # Normalize NVR for OCI compatibility (tildes are not allowed in tags)
+        NVR_NORMALIZED="${NVR//\~/-}"
+
+        IMAGE_URL="$(params.ociStorage).nvr-$NVR_NORMALIZED"
 
         echo "Selecting auth for $IMAGE_URL"
         select-oci-auth $IMAGE_URL > $HOME/auth.json


### PR DESCRIPTION
Closes [KONFLUX-11600](https://issues.redhat.com/browse/KONFLUX-11600)

Replace tildes with hyphens in NVR when constructing the IMAGE_URL, as tildes are not allowed in OCI tags.