### PR TITLE
Add lookaside-cache-url parameter

### DIFF
--- a/pipeline/build-rpm-package.yaml
+++ b/pipeline/build-rpm-package.yaml
@@ -142,6 +142,13 @@ spec:
       default: 'false'
       description: Enable cache proxy configuration
       type: string
+    - name: lookaside-cache-url
+      description: |
+        Base URL of the dist-git repository from which to fetch lookaside cache sources.
+        The package name will be appended to construct the full URL for
+        'dist-git-client --forked-from'.
+      type: string
+      default: https://src.fedoraproject.org/rpms/
   results:
     - description: ""
       name: CHAINS-GIT_URL
@@ -261,6 +268,8 @@ spec:
           value: $(params.monorepo-subdir)
         - name: build-architectures
           value: ["$(params.build-architectures[*])"]
+        - name: lookaside-cache-url
+          value: $(params.lookaside-cache-url)
     - name: prepare-mock-config
       retries: 3
       taskRef:

--- a/task/process-sources.yaml
+++ b/task/process-sources.yaml
@@ -43,6 +43,13 @@ spec:
       name: build-platforms
       type: array
       default: []
+    - description: |
+        Base URL of the dist-git repository from which to fetch lookaside cache sources.
+        The package name will be appended to construct the full URL for
+        'dist-git-client --forked-from'.
+      name: lookaside-cache-url
+      type: string
+      default: https://src.fedoraproject.org/rpms/
   results:
     - name: dependencies-artifact
       description: The Trusted Artifact URI pointing to the artifact with the rpm deps and source.
@@ -114,7 +121,10 @@ spec:
           specfile_name="${specfile_prefix}.spec"
         fi
 
-        dist-git-client --forked-from https://src.fedoraproject.org/rpms/$(params.package-name) sources
+        # Normalize URL to ensure proper path separator
+        lookaside_url="$(params.lookaside-cache-url)"
+        lookaside_url="${lookaside_url%/}"  # Remove trailing slash if present
+        dist-git-client --forked-from "${lookaside_url}/$(params.package-name)" sources
         # Make sure we use norpm: https://github.com/fedora-infra/rpmautospec/pull/319
         if [ "${MONOREPO_SUBDIR:-.}" = "." ]; then
           rpmautospec process-distgit "$specfile_name" "$specfile_name"


### PR DESCRIPTION
Closes #119 

Parameterize the --forked-from URL in process-sources to allow using different lookaside cache instances. The parameter specifies the base URL and the package name is appended automatically.

Defaults to https://src.fedoraproject.org/rpms/ for backwards compatibility.

---

I still hope to be able to use another cache store for Hummingbird where we aren't needing to rely on another distribution's lookaside cache, but this gives us more flexibility than we currently have, and is a step forward.