### PR TITLE
Normalize NVR for OCI tag compatibility in import-to-quay

### DIFF
--- a/pipeline/build-rpm-package.yaml
+++ b/pipeline/build-rpm-package.yaml
@@ -564,7 +564,7 @@ spec:
     - name: upload-to-quay
       params:
         - name: ociStorage
-          value: $(params.ociStorage)
+          value: $(params.ociStorage).built-artifacts
         - name: git-url
           value: $(params.git-url)
         - name: revision

--- a/task/import-to-quay.yaml
+++ b/task/import-to-quay.yaml
@@ -111,7 +111,8 @@ spec:
 
         # Get NVR from any SRPM
         NVR=$(<nvr.log)
-        IMAGE_URL="$(params.ociStorage).nvr-$NVR"
+
+        IMAGE_URL="$(params.ociStorage)"
 
         echo "Selecting auth for $IMAGE_URL"
         select-oci-auth $IMAGE_URL > $HOME/auth.json


### PR DESCRIPTION
Closes [KONFLUX-11600](https://issues.redhat.com/browse/KONFLUX-11600)

Replace tildes and plus with hyphens in NVR when constructing the IMAGE_URL, as these characters are not allowed in OCI tags.