### PR TITLE
Enable full SBOM with buildroot and syft-scanned data 

### DIFF
--- a/task/import-to-quay.yaml
+++ b/task/import-to-quay.yaml
@@ -199,6 +199,11 @@ spec:
         else
           echo "WARNING: ancestors.json not found in oras-staging, skipping source artifacts in SBOM" >&2
         fi
+        if [ -f buildroot_rpms.json ]; then
+          ARGS+=(--buildroot-arch-list buildroot_rpms.json)
+        else
+          echo "WARNING: buildroot_rpms.json not found in oras-staging, skipping buildroot data in SBOM" >&2
+        fi
         merge_syft_sbom.py "${ARGS[@]}"
     - name: show-sbom
       image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14

--- a/task/import-to-quay.yaml
+++ b/task/import-to-quay.yaml
@@ -138,52 +138,6 @@ spec:
         grep "Digest:" /tmp/oras.log | awk '{print $2}' | tr -d '\n' > $(results.IMAGE_DIGEST.path)
         echo -n $IMAGE_URL > $(results.IMAGE_URL.path)
         echo -n $NVR > $(results.NVR.path)
-    - name: explode-srpm
-      image: $(params.script-environment-image)
-      workingDir: /var/workdir/results/oras-staging
-      script: |
-        #!/usr/bin/env bash
-
-        # TODO(praiskup): RPM build code shouldn't be responsible for code
-        # scanning.  This heuristic for "best effort" archive extraction is
-        # incomplete and brittle (hence very risky), and should ideally be part
-        # of the Syft tooling (which likely performs all kinds of other
-        # heuristics, in a legitimate way).
-
-        export PS4='+ $(date "+%Y-%m-%d %H:%M:%S") '
-        set -x
-        # expects to parse all srpm files in /mnt
-        # writes output to /mnt/syft-sbom.json
-        SRCDIR=$(pwd)
-        TMPDIR=./syft-extracted
-        mkdir $TMPDIR
-
-        cd $TMPDIR || exit 1
-        for rpm in $SRCDIR/*.src.rpm ; do
-          echo "Extracting srpm $rpm"
-          rpm_fn=$(basename "$rpm")
-          cp "$rpm" .
-          rpm2archive -n "$rpm_fn" | tar -x
-          rm "$rpm_fn"
-        done
-
-        echo "Decompressing found archives"
-        ( # limit the scope of nullglob
-          shopt -s nullglob
-          for tarball in *.tar* *.tg* ; do
-            case $tarball in
-              *sig|*asc) continue ;;
-            esac
-            tar -vxf "$tarball"
-          done
-        )
-        #unzip ./*.zip &>/dev/null # missing in mock image
-        true archive explosion finished
-    - name: run-syft
-      image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.29.0@sha256:dc0da6b4448428e625271b542cc029ab03de92f75ea50d6d63b1d088d20bbd28
-      workingDir: /var/workdir/results/oras-staging
-      script: |
-        syft ./syft-extracted -o spdx-json > syft-sbom.json
     - name: merge-syft-sbom
       image: $(params.script-environment-image)
       workingDir: /var/workdir/results/oras-staging
@@ -193,6 +147,8 @@ spec:
         set -x
         # list dirs
         find . | sort
+        # Create empty SPDX doc as placeholder for --syft-sbom (to be removed later)
+        echo '{"spdxVersion":"SPDX-2.3","packages":[],"files":[],"relationships":[]}' > syft-sbom.json
         ARGS=(--rpm-dir . --syft-sbom syft-sbom.json --sbom-merged sbom-merged.json)
         if [ -f ancestors.json ]; then
           ARGS+=(--source-data ancestors.json)

--- a/task/rpmbuild.yaml
+++ b/task/rpmbuild.yaml
@@ -256,11 +256,16 @@ spec:
           rm "$rpm_fn"
           if [[ $rpm_fn == *.src.rpm ]]; then
             echo "Decompressing archives in srpm to $rpm_dir"
-            for tarball in *.tar* *.tg* ; do
-              case $tarball in
-                *sig|*asc) continue ;;
+            for archive in *.tar* *.tg* *.tb* *.txz *.tlz *.tzst *.crate *.zip *.xpi *.oxt ; do
+              [ -f "$archive" ] || continue
+              case $archive in
+                *sig|*asc)
+                  continue ;;
+                *.zip|*.xpi|*.oxt)
+                  unzip -o "$archive" && rm "$archive" ;;
+                *)
+                  tar -vxf "$archive" && rm "$archive" ;;
               esac
-              tar -vxf "$tarball" && rm "$tarball"
             done
             echo "Decompressing done"
           fi

--- a/task/rpmbuild.yaml
+++ b/task/rpmbuild.yaml
@@ -278,12 +278,11 @@ spec:
           exit 0
         fi
 
-        arch=$(ls results/)
         for rpm_dir in rpm-extracted/*; do
           [ -d "$rpm_dir" ] || continue
           rpm_nvra=$(basename "$rpm_dir")
           echo "Scanning $rpm_dir"
-          syft "$rpm_dir" -o spdx-json > "results/$arch/$rpm_nvra.sbom.json"
+          syft "$rpm_dir" -o spdx-json > "results/$(params.arch)/$rpm_nvra.sbom.json"
         done
     - name: create-trusted-artifact
       image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:0388f83b0a0f02e1b814f62e660a68c56f283fe3092371d00bf5ce743f53be2f

--- a/task/rpmbuild.yaml
+++ b/task/rpmbuild.yaml
@@ -227,6 +227,64 @@ spec:
         - mountPath: /ssh
           name: ssh
           readOnly: true
+    - name: extract-rpms
+      image: $(params.script-environment-image)
+      workingDir: /var/workdir
+      script: |
+        #!/usr/bin/env bash
+
+        if test "$(params.PLATFORM)" = localhost; then
+          exit 0
+        fi
+
+        export PS4='+ $(date "+%Y-%m-%d %H:%M:%S") '
+        set -x
+        shopt -s nullglob
+        workdir=$(pwd)
+        mkdir -p rpm-extracted
+        for rpm in results/*/*.rpm ; do
+          [ -f "$rpm" ] || continue
+          echo "Extracting rpm $rpm"
+          rpm_fn=$(basename "$rpm")
+          rpm_nvra=${rpm_fn%*.rpm}
+          rpm_dir="rpm-extracted/$rpm_nvra"
+          mkdir -p "$rpm_dir"
+          cd "$rpm_dir"
+          cp "$workdir/$rpm" .
+          echo "Extracting rpm $rpm_fn to $rpm_dir"
+          rpm2archive -n "$rpm_fn" | tar -xv
+          rm "$rpm_fn"
+          if [[ $rpm_fn == *.src.rpm ]]; then
+            echo "Decompressing archives in srpm to $rpm_dir"
+            for tarball in *.tar* *.tg* ; do
+              case $tarball in
+                *sig|*asc) continue ;;
+              esac
+              tar -vxf "$tarball" && rm "$tarball"
+            done
+            echo "Decompressing done"
+          fi
+          cd "$workdir"
+        done
+
+        true archive explosion finished
+
+    - name: run-syft
+      image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.29.0@sha256:dc0da6b4448428e625271b542cc029ab03de92f75ea50d6d63b1d088d20bbd28
+      workingDir: /var/workdir
+      script: |
+        #!/usr/bin/env bash
+        if test "$(params.PLATFORM)" = localhost; then
+          exit 0
+        fi
+
+        arch=$(ls results/)
+        for rpm_dir in rpm-extracted/*; do
+          [ -d "$rpm_dir" ] || continue
+          rpm_nvra=$(basename "$rpm_dir")
+          echo "Scanning $rpm_dir"
+          syft "$rpm_dir" -o spdx-json > "results/$arch/$rpm_nvra.sbom.json"
+        done
     - name: create-trusted-artifact
       image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:0388f83b0a0f02e1b814f62e660a68c56f283fe3092371d00bf5ce743f53be2f
       args:


### PR DESCRIPTION
* buildroot SBOM will be generated by `--buildroot-arch-list` with `buildroot_rpms.json` generated by `gather_rpms.py`
* instead of one syft-generated SBOM only for SRPM, now we generate SBOMs for every rpm including SRPM in each rpmbuild-<arch> task, and merged all of them, except the unselected SRPMs into the final SBOM.
* `--syft-sbom` option of `merge_sboms.py` is knocked out and we will remove it later.