### PR TITLE
feat(HUM-842): add result for lookaside cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ run *Mock* builds in the appropriate environment.
 For more technical details, see the [architecture
 overview](docs/architecture.md).
 
+After a build completes, the pipeline records the [lookaside cache
+configuration](docs/lookaside-cache.md) in the build attestation so consumers
+can independently verify source provenance.
+
 **About to [start building RPMs in Konflux](docs/onboarding.md)?  Happy
 building!**
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -69,6 +69,10 @@ using [MPC][].
 - **process-sources**
     - Downloads the precise set of source files (typically tarballs) from the
       corresponding DistGit lookaside cache.
+    - Emits a `LOOKASIDE_CONFIG` result containing the cache location and URL
+      pattern used to download sources, enabling consumers to reconstruct
+      download URLs for attestation verification.  See
+      [lookaside-cache.md](lookaside-cache.md) for details.
     - This task provides a "frozen" set of source files for the subsequent RPM
       builds.  The output from this task (see the ociStorage parameter)
       represents the final set of source code files that will *exclusively*

--- a/docs/lookaside-cache.md
+++ b/docs/lookaside-cache.md
@@ -1,0 +1,111 @@
+# Lookaside Cache Configuration
+
+The RPM Build Pipeline records the lookaside cache configuration used to
+download sources as a pipeline result called `LOOKASIDE_CONFIG`.  This allows
+consumers to independently verify build inputs by reconstructing the exact
+URLs that were used to fetch source tarballs.
+
+## Retrieving LOOKASIDE_CONFIG from a build attestation
+
+After a successful pipeline run, extract the configuration from the build
+attestation:
+
+```bash
+cosign download attestation $IMAGE_URL | \
+  jq -r '.payload' | base64 -d | \
+  jq '.predicate.runDetails.byproducts[] |
+    select(.name == "LOOKASIDE_CONFIG") | .content'
+```
+
+Example output:
+
+```json
+{
+  "package": "glibc",
+  "lookaside_location": "https://src.fedoraproject.org",
+  "uri_pattern": "repo/pkgs/rpms/{name}/{filename}/{hashtype}/{hash}/{filename}"
+}
+```
+
+## Reconstructing source download URLs
+
+The `sources` file in the root of each dist-git repository lists every
+source tarball with its hash.  The current format is:
+
+```text
+SHA512 (glibc-2.39.tar.xz) = 476350092e854...
+SHA512 (glibc-2.39-fedora.patch) = 8b0a02c1012...
+```
+
+Substitute the placeholders in `uri_pattern` using values from the
+`sources` file and `LOOKASIDE_CONFIG`:
+
+| Placeholder  | Source                       | Example              |
+| ------------ | ---------------------------- | -------------------- |
+| `{name}`     | `LOOKASIDE_CONFIG.package`   | `glibc`              |
+| `{filename}` | filename from sources file   | `glibc-2.39.tar.xz` |
+| `{hashtype}` | hash prefix in sources file  | `sha512`             |
+| `{hash}`     | hash value from sources file | `476350092e854...`   |
+
+The full download URL is `{lookaside_location}/{uri_pattern}` with
+substitutions applied:
+
+```text
+https://src.fedoraproject.org/repo/pkgs/rpms/glibc/\
+  glibc-2.39.tar.xz/sha512/476350092e854.../glibc-2.39.tar.xz
+```
+
+## Scripted example
+
+```bash
+# Parse the LOOKASIDE_CONFIG
+config=$(cosign download attestation "$IMAGE_URL" | \
+  jq -r '.payload' | base64 -d | \
+  jq -r '.predicate.runDetails.byproducts[] |
+    select(.name == "LOOKASIDE_CONFIG") | .content')
+
+location=$(echo "$config" | jq -r '.lookaside_location')
+pattern=$(echo "$config" | jq -r '.uri_pattern')
+package=$(echo "$config" | jq -r '.package')
+
+# For each entry in the sources file, construct the download URL
+while IFS= read -r line; do
+  hashtype=$(echo "$line" \
+    | sed -E 's/^([A-Z0-9]+) .*/\1/' \
+    | tr '[:upper:]' '[:lower:]')
+  filename=$(echo "$line" \
+    | sed -E 's/^[A-Z0-9]+ \(([^)]+)\).*/\1/')
+  hash=$(echo "$line" | sed -E 's/.*= //')
+
+  url="${location}/${pattern}"
+  url="${url//\{name\}/$package}"
+  url="${url//\{filename\}/$filename}"
+  url="${url//\{hashtype\}/$hashtype}"
+  url="${url//\{hash\}/$hash}"
+
+  echo "$url"
+done < sources
+```
+
+## Distribution examples
+
+**Fedora** (`https://src.fedoraproject.org`):
+
+```text
+https://src.fedoraproject.org/repo/pkgs/rpms/glibc/\
+  glibc-2.39.tar.xz/sha512/{hash}/glibc-2.39.tar.xz
+```
+
+**CentOS Stream** (`https://sources.stream.centos.org`):
+
+```text
+https://sources.stream.centos.org/sources/rpms/kernel/\
+  linux-6.12.tar.xz/sha512/{hash}/linux-6.12.tar.xz
+```
+
+**Hummingbird** (`https://d1766whheab9hg.cloudfront.net`):
+
+```text
+https://d1766whheab9hg.cloudfront.net/rpms/glibc/\
+  glibc-2.39.tar.xz/sha512/{hash}/glibc-2.39.tar.xz
+```

--- a/docs/lookaside-cache.md
+++ b/docs/lookaside-cache.md
@@ -36,29 +36,29 @@ Example output:
 ## Reconstructing source download URLs
 
 The `sources` file in the root of each dist-git repository lists every
-source tarball with its hash.  The current format is:
+source tarball with its hash.  For example, the `bash` package has:
 
 ```text
-SHA512 (glibc-2.39.tar.xz) = 476350092e854...
-SHA512 (glibc-2.39-fedora.patch) = 8b0a02c1012...
+SHA512 (bash-5.3.tar.gz) = 05ef640e8ba011d10f858a270c626daa42ed5a75789d0298ae0ced9b2ebaf93d94d8ed5a211ac30cd34e82af8865e50024144c88a3c979bee7c38e449350e02e
+SHA512 (bash-5.3.tar.gz.sig) = e9da98e993528d69bec9c6da272eb7a96858b4ba33487435f584c7df2d73c3ce82f373b5277cc3a7d8dc9ee04410dc06ce476d3f9ade097121bea0570abe07bc
 ```
 
 Substitute the placeholders in `uri_pattern` using values from the
 `sources` file and `LOOKASIDE_CONFIG`:
 
-| Placeholder  | Source                       | Example              |
-| ------------ | ---------------------------- | -------------------- |
-| `{name}`     | `LOOKASIDE_CONFIG.package`   | `glibc`              |
-| `{filename}` | filename from sources file   | `glibc-2.39.tar.xz` |
-| `{hashtype}` | hash prefix in sources file  | `sha512`             |
-| `{hash}`     | hash value from sources file | `476350092e854...`   |
+| Placeholder  | Source                       | Example            |
+| ------------ | ---------------------------- | ------------------ |
+| `{name}`     | `LOOKASIDE_CONFIG.package`   | `bash`             |
+| `{filename}` | filename from sources file   | `bash-5.3.tar.gz`  |
+| `{hashtype}` | hash prefix in sources file  | `sha512`           |
+| `{hash}`     | hash value from sources file | `05ef640e8ba01...` |
 
 The full download URL is `{lookaside_location}/{uri_pattern}` with
-substitutions applied:
+substitutions applied.  For the `bash` sources file above, this produces:
 
 ```text
-https://src.fedoraproject.org/repo/pkgs/rpms/glibc/\
-  glibc-2.39.tar.xz/sha512/476350092e854.../glibc-2.39.tar.xz
+https://src.fedoraproject.org/repo/pkgs/rpms/bash/bash-5.3.tar.gz/sha512/05ef640e8ba011d10f858a270c626daa42ed5a75789d0298ae0ced9b2ebaf93d94d8ed5a211ac30cd34e82af8865e50024144c88a3c979bee7c38e449350e02e/bash-5.3.tar.gz
+https://src.fedoraproject.org/repo/pkgs/rpms/bash/bash-5.3.tar.gz.sig/sha512/e9da98e993528d69bec9c6da272eb7a96858b4ba33487435f584c7df2d73c3ce82f373b5277cc3a7d8dc9ee04410dc06ce476d3f9ade097121bea0570abe07bc/bash-5.3.tar.gz.sig
 ```
 
 ## Scripted example
@@ -101,20 +101,17 @@ done < sources
 **Fedora** (`https://src.fedoraproject.org`):
 
 ```text
-https://src.fedoraproject.org/repo/pkgs/rpms/glibc/\
-  glibc-2.39.tar.xz/sha512/{hash}/glibc-2.39.tar.xz
+https://src.fedoraproject.org/repo/pkgs/rpms/bash/bash-5.3.tar.gz/sha512/{hash}/bash-5.3.tar.gz
 ```
 
 **CentOS Stream** (`https://sources.stream.centos.org`):
 
 ```text
-https://sources.stream.centos.org/sources/rpms/kernel/\
-  linux-6.12.tar.xz/sha512/{hash}/linux-6.12.tar.xz
+https://sources.stream.centos.org/sources/rpms/bash/bash-5.3.tar.gz/sha512/{hash}/bash-5.3.tar.gz
 ```
 
 **Hummingbird** (`https://d1766whheab9hg.cloudfront.net`):
 
 ```text
-https://d1766whheab9hg.cloudfront.net/rpms/glibc/\
-  glibc-2.39.tar.xz/sha512/{hash}/glibc-2.39.tar.xz
+https://d1766whheab9hg.cloudfront.net/rpms/bash/bash-5.3.tar.gz/sha512/{hash}/bash-5.3.tar.gz
 ```

--- a/docs/lookaside-cache.md
+++ b/docs/lookaside-cache.md
@@ -10,18 +10,24 @@ URLs that were used to fetch source tarballs.
 After a successful pipeline run, extract the configuration from the build
 attestation:
 
+Konflux currently produces SLSA v0.2 attestations.  Task results are stored
+under `predicate.buildConfig.tasks[].results`:
+
 ```bash
 cosign download attestation $IMAGE_URL | \
   jq -r '.payload' | base64 -d | \
-  jq '.predicate.runDetails.byproducts[] |
-    select(.name == "LOOKASIDE_CONFIG") | .content'
+  jq '.predicate.buildConfig.tasks[]
+    | select(.results != null)
+    | .results[]
+    | select(.name == "LOOKASIDE_CONFIG")
+    | .value' -r
 ```
 
 Example output:
 
 ```json
 {
-  "package": "glibc",
+  "package": "setup",
   "lookaside_location": "https://src.fedoraproject.org",
   "uri_pattern": "repo/pkgs/rpms/{name}/{filename}/{hashtype}/{hash}/{filename}"
 }
@@ -61,8 +67,11 @@ https://src.fedoraproject.org/repo/pkgs/rpms/glibc/\
 # Parse the LOOKASIDE_CONFIG
 config=$(cosign download attestation "$IMAGE_URL" | \
   jq -r '.payload' | base64 -d | \
-  jq -r '.predicate.runDetails.byproducts[] |
-    select(.name == "LOOKASIDE_CONFIG") | .content')
+  jq -r '.predicate.buildConfig.tasks[]
+    | select(.results != null)
+    | .results[]
+    | select(.name == "LOOKASIDE_CONFIG")
+    | .value')
 
 location=$(echo "$config" | jq -r '.lookaside_location')
 pattern=$(echo "$config" | jq -r '.uri_pattern')

--- a/docs/lookaside-cache.md
+++ b/docs/lookaside-cache.md
@@ -61,6 +61,17 @@ https://src.fedoraproject.org/repo/pkgs/rpms/bash/bash-5.3.tar.gz/sha512/05ef640
 https://src.fedoraproject.org/repo/pkgs/rpms/bash/bash-5.3.tar.gz.sig/sha512/e9da98e993528d69bec9c6da272eb7a96858b4ba33487435f584c7df2d73c3ce82f373b5277cc3a7d8dc9ee04410dc06ce476d3f9ade097121bea0570abe07bc/bash-5.3.tar.gz.sig
 ```
 
+## Packages with no lookaside sources
+
+Some packages (e.g., `setup`) ship all their source files directly in the
+dist-git repository and have an empty or missing `sources` file.  The
+`LOOKASIDE_CONFIG` result is still emitted for these builds — it reflects
+the lookaside cache configuration that *would have been used*, not that
+files were actually downloaded.  When consuming `LOOKASIDE_CONFIG`, check
+whether the `sources` file has any entries before attempting to reconstruct
+download URLs.  If it is empty, no tarballs were fetched from the
+lookaside cache and all build inputs came from the repository itself.
+
 ## Scripted example
 
 ```bash

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -18,6 +18,8 @@ Below is the set of supported parameters accepted by the pipeline.
 | mock-config-template-filename-in-sources | If Mock Config template exists within source directory, specify where. | ""                                  |
 | ociArtifactExpiresAfter | How long Trusted Artifacts should be retained                                    | 14d                                 |
 | target-distribution | Target distribution. The pipeline expands spec file using macros from the target distribution. Typically specified as ID-VERSION_ID (see /etc/os-release), e.g., rhel-11 | fedora-rawhide                      |
+| forked-from             | URL prefix of the upstream dist-git repository for lookaside cache resolution. The package name will be appended to this prefix. | `https://src.fedoraproject.org/rpms/` |
+| dist-git-client-configdir | Path to the directory containing the dist-git-client configuration. Passed to dist-git-client via `--configdir` option. | "" |
 
 ## Parametrizing timeouts
 

--- a/pipeline/build-rpm-package.yaml
+++ b/pipeline/build-rpm-package.yaml
@@ -150,6 +150,19 @@ spec:
       default: 'fedora-rawhide'
       description: Target distribution. The pipeline expands spec file using macros from the target distribution. Typically specified as ID-VERSION_ID (see /etc/os-release), e.g., rhel-11
       type: string
+    - name: forked-from
+      description: |
+        URL prefix of the upstream dist-git repository for lookaside cache resolution.
+        The package name will be appended to this prefix.
+        If not specified, defaults to https://src.fedoraproject.org/rpms/.
+      type: string
+      default: "https://src.fedoraproject.org/rpms/"
+    - name: dist-git-client-configdir
+      description: |
+        Path to the directory containing the dist-git-client configuration.
+        Passed to dist-git-client via --configdir option.
+      type: string
+      default: ""
   results:
     - description: ""
       name: CHAINS-GIT_URL
@@ -157,6 +170,11 @@ spec:
     - description: ""
       name: CHAINS-GIT_COMMIT
       value: $(tasks.clone-repository.results.commit)
+    - name: LOOKASIDE_CONFIG
+      description: |
+        JSON object containing the lookaside cache configuration used to download sources.
+        Contains lookaside_location, uri_pattern, and package name for reconstructing source URLs.
+      value: $(tasks.process-sources.results.LOOKASIDE_CONFIG)
     - description: ""
       name: IMAGE_URL
       value: $(tasks.upload-to-quay.results.IMAGE_URL)
@@ -273,6 +291,10 @@ spec:
           value: ["$(params.build-platforms[*])"]
         - name: target-distribution
           value: $(params.target-distribution)
+        - name: forked-from
+          value: $(params.forked-from)
+        - name: dist-git-client-configdir
+          value: $(params.dist-git-client-configdir)
     - name: prepare-mock-config
       retries: 3
       taskRef:

--- a/task/process-sources.yaml
+++ b/task/process-sources.yaml
@@ -51,9 +51,28 @@ spec:
       name: target-distribution
       type: string
       default: 'fedora-rawhide'
+    - description: |
+        URL prefix of the upstream dist-git repository for lookaside cache resolution.
+        The package name will be appended to this prefix.
+        If not specified, defaults to https://src.fedoraproject.org/rpms/.
+      name: forked-from
+      type: string
+      default: "https://src.fedoraproject.org/rpms/"
+    - description: |
+        Path to the directory containing the dist-git-client configuration.
+        Passed to dist-git-client via --configdir option.
+      name: dist-git-client-configdir
+      type: string
+      default: ""
   results:
     - name: dependencies-artifact
       description: The Trusted Artifact URI pointing to the artifact with the rpm deps and source.
+      type: string
+    - name: LOOKASIDE_CONFIG
+      description: |
+        JSON object containing the lookaside cache configuration used to download sources.
+        Contains lookaside_location, uri_pattern, and package name. Consumers can use this
+        with the sources file to reconstruct full download URLs for attestation verification.
       type: string
     - name: skip-mpc-tasks
       description: |
@@ -113,7 +132,8 @@ spec:
       image: $(params.script-environment-image)
       script: |
         set -ex
-        cd "/var/workdir/source/${MONOREPO_SUBDIR}"
+        source_root="/var/workdir/source"
+        cd "${source_root}/${MONOREPO_SUBDIR}"
 
         if test "$(params.specfile)" != "null" ; then
           specfile_name=$(params.specfile)
@@ -126,7 +146,57 @@ spec:
         CURL_HOME=$(mktemp -d)
         echo 'header = "Accept-Encoding: identity"' > $CURL_HOME/.curlrc
 
-        CURL_HOME="$CURL_HOME" dist-git-client --forked-from https://src.fedoraproject.org/rpms/$(params.package-name) sources
+        # Build dist-git-client arguments
+        dgc_args=""
+        if [ -n "$(params.dist-git-client-configdir)" ]; then
+          # Configdir is relative to source root, not current working directory
+          dgc_args="$dgc_args --configdir ${source_root}/$(params.dist-git-client-configdir)"
+        fi
+        # Ensure forked-from URL has trailing slash before appending package name
+        forked_from_url="$(params.forked-from)"
+        forked_from_url="${forked_from_url%/}/"
+        dgc_args="$dgc_args --forked-from ${forked_from_url}$(params.package-name)"
+
+        CURL_HOME="$CURL_HOME" dist-git-client $dgc_args sources
+
+        # Determine lookaside config and write to result for attestation
+        if [ -n "$(params.dist-git-client-configdir)" ]; then
+          config_dir="${source_root}/$(params.dist-git-client-configdir)"
+        else
+          config_dir="/etc/dist-git-client"
+        fi
+
+        hostname=$(echo "${forked_from_url}" | sed -E 's|^https?://([^/]+).*|\1|')
+
+        read -r lookaside_location uri_pattern < <(python3 -c "
+        import configparser, glob, sys
+        hostname = sys.argv[1]
+        config_dir = sys.argv[2]
+        for path in sorted(glob.glob(config_dir + '/*.ini')):
+            cp = configparser.ConfigParser()
+            cp.read(path)
+            for section in cp.sections():
+                hosts = cp.get(section, 'clone_hostnames', fallback='')
+                if hostname in hosts:
+                    loc = cp.get(section, 'lookaside_location', fallback='')
+                    pat = cp.get(section, 'lookaside_uri_pattern', fallback='')
+                    if loc:
+                        print(loc, pat)
+                        sys.exit(0)
+        base = 'https://src.fedoraproject.org'
+        pat = 'repo/pkgs/rpms/{name}/{filename}/{hashtype}/{hash}/{filename}'
+        print(base, pat)
+        " "$hostname" "$config_dir")
+
+        jq -n \
+          --arg package "$(params.package-name)" \
+          --arg lookaside_location "$lookaside_location" \
+          --arg uri_pattern "$uri_pattern" \
+          '{package: $package,
+           lookaside_location: $lookaside_location,
+           uri_pattern: $uri_pattern}' \
+          > "$(results.LOOKASIDE_CONFIG.path)"
+
         # Make sure we use norpm: https://github.com/fedora-infra/rpmautospec/pull/319
         if [ "${MONOREPO_SUBDIR:-.}" = "." ]; then
           rpmautospec process-distgit "$specfile_name" "$specfile_name"
@@ -140,7 +210,7 @@ spec:
           echo "'rpmautospec process-distgit' is not supported for monorepos"
         fi
 
-        cd "/var/workdir/source"
+        cd "${source_root}"
         git diff
 
         # We remove the .git repository here to ensure that historical code does


### PR DESCRIPTION
## Summary

Adds a `LOOKASIDE_CONFIG` pipeline result that records which lookaside cache was used to download sources during `process-sources`. This enables consumers to independently verify source provenance by reconstructing the exact download URLs from the build attestation.

### Changes

- **New pipeline result**: `LOOKASIDE_CONFIG` — a JSON object containing `package`, `lookaside_location`, and `uri_pattern`
- **New pipeline/task params**:
  - `forked-from` — upstream dist-git repository URL prefix (defaults to `https://src.fedoraproject.org/rpms/`)
  - `dist-git-client-configdir` — path to dist-git-client `.ini` config directory (defaults to system config)
- **INI config parsing** uses python3 `configparser` to find the matching lookaside config based on the `forked-from` hostname
- **JSON output** uses `jq -n --arg` for safe construction
- **New documentation**: `docs/lookaside-cache.md` — end-to-end guide for extracting and using the config

### Retrieving from a build attestation

```bash
cosign download attestation $IMAGE_URL | \
  jq -r '.payload' | base64 -d | \
  jq '.predicate.runDetails.byproducts[] |
    select(.name == "LOOKASIDE_CONFIG") | .content'
```

### Example values

**Fedora:**
```json
{"package":"glibc","lookaside_location":"https://src.fedoraproject.org","uri_pattern":"repo/pkgs/rpms/{name}/{filename}/{hashtype}/{hash}/{filename}"}
```

**CentOS Stream:**
```json
{"package":"kernel","lookaside_location":"https://sources.stream.centos.org","uri_pattern":"sources/rpms/{name}/{filename}/{hashtype}/{hash}/{filename}"}
```

**Hummingbird:**
```json
{"package":"glibc","lookaside_location":"https://d1766whheab9hg.cloudfront.net","uri_pattern":"rpms/{name}/{filename}/{hashtype}/{hash}/{filename}"}
```

See [docs/lookaside-cache.md](docs/lookaside-cache.md) for full usage details including how to reconstruct source download URLs from the `sources` file.