### PR TITLE
Explicit archive extensions

### DIFF
--- a/task/rpmbuild.yaml
+++ b/task/rpmbuild.yaml
@@ -256,11 +256,9 @@ spec:
           rm "$rpm_fn"
           if [[ $rpm_fn == *.src.rpm ]]; then
             echo "Decompressing archives in srpm to $rpm_dir"
-            for archive in *.tar* *.tg* *.tb* *.txz *.tlz *.tzst *.crate *.zip *.xpi *.oxt ; do
+            for archive in *tar *.tbz2 *.tar.gz *.tar.xz *.tar.bz2 *.tar.zst *.tar.lz *.tgz *.tbz *.txz *.tlz *.tzst *.crate *.zip *.xpi *.oxt *.gem ; do
               [ -f "$archive" ] || continue
               case $archive in
-                *sig|*asc)
-                  continue ;;
                 *.zip|*.xpi|*.oxt)
                   unzip -o "$archive" && rm "$archive" ;;
                 *)


### PR DESCRIPTION
There are not only .tgz.sig, but also .tgz.sha256sum and others, so better to be explicit than fail on random files.