### PR TITLE
Replace appstudio-utils image with task-runner

### DIFF
--- a/task/import-to-quay.yaml
+++ b/task/import-to-quay.yaml
@@ -162,7 +162,7 @@ spec:
         fi
         merge_sboms.py "${ARGS[@]}"
     - name: show-sbom
-      image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
+      image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
       workingDir: /var/workdir/results/oras-staging
       script: |
         #!/usr/bin/env bash

--- a/task/import-to-quay.yaml
+++ b/task/import-to-quay.yaml
@@ -202,7 +202,7 @@ spec:
          $(cat $(results.IMAGE_URL.path))@$(cat $(results.IMAGE_DIGEST.path))
       workingDir: /var/workdir
     - name: report-sbom-url
-      image: quay.io/konflux-ci/yq:latest@sha256:c32538822bd26e0964090c689a1bc640d799bac62290c486b66055ddaf44748a
+      image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
       workingDir: /var/workdir/results/oras-staging
       script: |
         #!/usr/bin/env bash


### PR DESCRIPTION
`appstudio-utils` will be decommissioned soon. Task-runner has all the tools needed in this task and
there are no operations, that would require privileges.

For the second change, see commit description.