### PR TITLE
correct resultdir permissions before rsync

### DIFF
--- a/task/rpmbuild.yaml
+++ b/task/rpmbuild.yaml
@@ -202,6 +202,13 @@ spec:
         remote_cmd stat -c "'%a %U:%G %n'" "$HOMEDIR/results/"'*'
         remote_cmd getfacl "$HOMEDIR/results/"
 
+        # Ensure result files are world-readable before rsync.  Mock
+        # copies RPMs to the resultdir inheriting the host's umask,
+        # which on some builders is 0027 — stripping the other-read
+        # bit and causing rsync Permission denied for files owned by
+        # the container's subuid.
+        remote_cmd podman unshare chmod -R a+rX "$HOMEDIR/results/"
+
         resultdir="$workdir/results/$(params.arch)"
         mkdir -p "$resultdir"
         receive "$HOMEDIR/results/" "$resultdir"

--- a/task/rpmbuild.yaml
+++ b/task/rpmbuild.yaml
@@ -197,6 +197,11 @@ spec:
         remote_cmd "tar xvfO '$HOMEDIR'/results/chroot_scan.tar.gz 2>&1 | cat"
         $success
 
+        echo "DEBUG: resultdir file ownership and permissions on remote host"
+        remote_cmd ls -la "$HOMEDIR/results/"
+        remote_cmd stat -c "'%a %U:%G %n'" "$HOMEDIR/results/"'*'
+        remote_cmd getfacl "$HOMEDIR/results/"
+
         resultdir="$workdir/results/$(params.arch)"
         mkdir -p "$resultdir"
         receive "$HOMEDIR/results/" "$resultdir"

--- a/task/rpmbuild.yaml
+++ b/task/rpmbuild.yaml
@@ -195,12 +195,13 @@ spec:
         # https://github.com/rpm-software-management/dnf5/issues/1673
         # (sync with calculate-deps.yaml)
         remote_cmd "tar xvfO '$HOMEDIR'/results/chroot_scan.tar.gz 2>&1 | cat"
-        $success
 
         echo "DEBUG: resultdir file ownership and permissions on remote host"
-        remote_cmd ls -la "$HOMEDIR/results/"
-        remote_cmd stat -c "'%a %U:%G %n'" "$HOMEDIR/results/"'*'
-        remote_cmd getfacl "$HOMEDIR/results/"
+        remote_cmd ls -la "$HOMEDIR/results/" || true
+        remote_cmd stat -c "'%a %U:%G %n'" "$HOMEDIR/results/"'*' || true
+        remote_cmd getfacl "$HOMEDIR/results/" || true
+
+        $success
 
         # Ensure result files are world-readable before rsync.  Mock
         # copies RPMs to the resultdir inheriting the host's umask,


### PR DESCRIPTION
**Summary**                                                                                                                                                                                                           
- Adds debug logging (ls -la, stat, getfacl) on the remote results directory before rsync                                                                                                                         
- Adds podman unshare chmod -R a+rX to ensure result files are world-readable before rsync                                                                                                                        
                                                                                                                                                                                                                   
**Root cause:** Mock copies RPMs to the resultdir inheriting the host's umask. On some builders the umask is 0027, producing 0640 files. Files owned by the container's subuid become inaccessible to the SSH user,  causing rsync Permission denied. Observed on specific x86_64 hosts; aarch64 and other x86_64 hosts with umask 0022 are unaffected. 

Fixes: #213 