### PR TITLE
Don't re-expand specfiles for ancestors.json

### DIFF
--- a/task/calculate-deps.yaml
+++ b/task/calculate-deps.yaml
@@ -168,6 +168,7 @@ spec:
             gen_ancestors_from_src.py \
                 -s /source \
                 --specfile /results/expanded-spec.txt \
+                --already-expanded \
                 --forked-from "https://src.fedoraproject.org/rpms/$(params.package-name)" \
                 -o /results/ancestors.json
 

--- a/task/rpmbuild.yaml
+++ b/task/rpmbuild.yaml
@@ -230,6 +230,7 @@ spec:
               gen_ancestors_from_src.py \
                   -s /source \
                   --specfile /results/expanded-spec.txt \
+                  --already-expanded \
                   --forked-from "https://src.fedoraproject.org/rpms/$(params.package-name)" \
                   -o /results/ancestors.json
           mkdir -p "$resultdir/results"


### PR DESCRIPTION
Related: https://github.com/konflux-ci/rpmbuild-pipeline/issues/218

Depends-on: https://github.com/konflux-ci/rpmbuild-pipeline-environment-container/pull/198
Depends-on: https://github.com/konflux-ci/rpmbuild-pipeline/pull/212