### PR TITLE
fix missing expanded spec

### DIFF
--- a/task/calculate-deps.yaml
+++ b/task/calculate-deps.yaml
@@ -158,28 +158,32 @@ spec:
             --lockfile /results/buildroot_lock.json \
             --output-repo /results/buildroot_repo
 
-        # Generate ancestors data for SBOM using the expanded specfile
-        # produced by the expand_spec mock plugin.
-        remote_cmd podman run -u mockbuilder \
-                              --network=none \
-                              -v "$HOMEDIR/source:/source" \
-                              -v "$HOMEDIR/results:/results" \
-                              --privileged --rm -ti "$mock_img" \
-            gen_ancestors_from_src.py \
-                -s /source \
-                --specfile /results/expanded-spec.txt \
-                --already-expanded \
-                --forked-from "https://src.fedoraproject.org/rpms/$(params.package-name)" \
-                -o /results/ancestors.json
+        if remote_cmd test -f "$HOMEDIR/results/expanded-spec.txt" ; then
+          # Generate ancestors data for SBOM using the expanded specfile
+          # produced by the expand_spec mock plugin.
+          remote_cmd podman run -u mockbuilder \
+                                --network=none \
+                                -v "$HOMEDIR/source:/source" \
+                                -v "$HOMEDIR/results:/results" \
+                                --privileged --rm -ti "$mock_img" \
+              gen_ancestors_from_src.py \
+                  -s /source \
+                  --specfile /results/expanded-spec.txt \
+                  --already-expanded \
+                  --forked-from "https://src.fedoraproject.org/rpms/$(params.package-name)" \
+                  -o /results/ancestors.json
+        fi
 
         resultdir=$workdir/results/$(params.arch)/results
         mkdir -p "$resultdir"
         # Send only repo and lockfile, ignore other artifacts
         receive "$HOMEDIR/results/buildroot_lock.json" "$resultdir/buildroot_lock.json"
-        receive "$HOMEDIR/results/buildroot_repo" "$resultdir"
-        receive "$HOMEDIR/results/ancestors.json" "$resultdir/ancestors.json"
         cat "$resultdir/buildroot_lock.json"
-        cat "$resultdir/ancestors.json"
+        receive "$HOMEDIR/results/buildroot_repo" "$resultdir"
+        if remote_cmd test -f "$HOMEDIR/results/ancestors.json" ; then
+          receive "$HOMEDIR/results/ancestors.json" "$resultdir/ancestors.json"
+          cat "$resultdir/ancestors.json"
+        fi
       volumeMounts:
         - mountPath: /ssh
           name: ssh

--- a/task/rpmbuild.yaml
+++ b/task/rpmbuild.yaml
@@ -162,10 +162,17 @@ spec:
           remote_cmd podman unshare setfacl -m g:135:r-x -m default:g:135:r-x "$HOMEDIR/buildroot"
           send "$workdir/results/$(params.arch)/results" "$HOMEDIR/buildroot"
 
+          BRANCH=$(params.target-branch)
+          BRANCH=${BRANCH,,}
+          if [[ $BRANCH == rhel-6* ]] ; then
+            RHEL6_IGNORE_SBOM="--disable-plugin=expand_spec"
+          else
+            RHEL6_IGNORE_SBOM=""
+          fi
           remote_cmd podman run --network=none \
                                 -v "$HOMEDIR/buildroot:/buildroot" \
                                 "${podman_params[@]}" \
-              mock --hermetic-build \
+              mock $RHEL6_IGNORE_SBOM --hermetic-build \
                   /buildroot/results/buildroot_lock.json \
                   /buildroot/results/buildroot_repo \
                   --spec /source/$specfile_name \


### PR DESCRIPTION
RHEL6 doesn't have rpmspec tool. As we don't need SBOM for these packages, workarounds to ignore non-existent ancestors.json and related code is being bypassed.