### PR TITLE
fix: add retries: 3 to calculate-deps-* tasks to handle transient CDN 404s

### DIFF
--- a/pipeline/build-rpm-package.yaml
+++ b/pipeline/build-rpm-package.yaml
@@ -300,6 +300,7 @@ spec:
         - name: ociArtifactExpiresAfter
           value: $(params.ociArtifactExpiresAfter)
     - name: calculate-deps-x86-64
+      retries: 3
       runAfter:
         - process-sources
         - prepare-mock-config
@@ -372,6 +373,7 @@ spec:
           - name: pathInRepo
             value: task/rpmbuild.yaml
     - name: calculate-deps-i686
+      retries: 3
       runAfter:
         - process-sources
         - prepare-mock-config
@@ -444,6 +446,7 @@ spec:
           - name: pathInRepo
             value: task/rpmbuild.yaml
     - name: calculate-deps-aarch64
+      retries: 3
       runAfter:
         - process-sources
         - prepare-mock-config
@@ -516,6 +519,7 @@ spec:
           - name: pathInRepo
             value: task/rpmbuild.yaml
     - name: calculate-deps-s390x
+      retries: 3
       runAfter:
         - process-sources
         - prepare-mock-config
@@ -588,6 +592,7 @@ spec:
           - name: pathInRepo
             value: task/rpmbuild.yaml
     - name: calculate-deps-ppc64le
+      retries: 3
       runAfter:
         - process-sources
         - prepare-mock-config


### PR DESCRIPTION
## Problem

During performance testing with 10 parallel RPM build pipelines on a
Konflux staging cluster, all 10 pipelines consistently failed across
two back-to-back runs. The failing tasks were `calculate-deps-x86-64`
and `calculate-deps-aarch64`, which hit transient HTTP 404 errors from
the Fedora Rawhide CDN:

```
"GET .../Packages/c/curl-8.20.0~rc3-1.fc45.x86_64.rpm HTTP/1.1" 404
ERROR:__main__:Download failed: .../curl-8.20.0~rc3-1.fc45.x86_64.rpm
ERROR:__main__:RPM deps downloading failed
```

**Root cause:** Fedora Rawhide is a rolling release. A package
(`curl-8.20.0~rc3`) was superseded by its GA release between repodata
generation and the actual CDN download. All 10 parallel builds that
tried to download it simultaneously hit the 404. The issue is transient
— the CDN stabilises within hours — but without retries a single
flaky download causes the entire pipeline to fail permanently.

## Fix

Add `retries: 3` to all five `calculate-deps-*` tasks:

- `calculate-deps-x86-64`
- `calculate-deps-i686`
- `calculate-deps-aarch64`
- `calculate-deps-s390x`
- `calculate-deps-ppc64le`

This aligns them with every other task in the pipeline, which already
has `retries: 3` (`store-start-time`, `init`, `clone-repository`,
`process-sources`, `prepare-mock-config`). With retries in place, a
transient CDN 404 will be automatically recovered on the next attempt
without failing the whole pipeline.

## Change

```yaml
# Before (all 5 tasks):
- name: calculate-deps-x86-64
  runAfter: [...]

# After:
- name: calculate-deps-x86-64
  retries: 3
  runAfter: [...]
```

5 lines added, 0 lines removed.

Signed-off-by: Subrata Modak <smodak@redhat.com>
Assisted-by: CursorAI

Made with [Cursor](https://cursor.com)