### PR TITLE
feat: add purl-rpm-namespace pipeline parameter for SBOM generation

### DIFF
--- a/pipeline/build-rpm-package.yaml
+++ b/pipeline/build-rpm-package.yaml
@@ -150,6 +150,10 @@ spec:
       default: 'fedora-rawhide'
       description: Target distribution. The pipeline expands spec file using macros from the target distribution. Typically specified as ID-VERSION_ID (see /etc/os-release), e.g., rhel-11
       type: string
+    - name: purl-rpm-namespace
+      description: PURL namespace for RPM packages in the generated SBOM (e.g., fedora, redhat)
+      type: string
+      default: "fedora"
   results:
     - description: ""
       name: CHAINS-GIT_URL
@@ -685,6 +689,8 @@ spec:
           value: $(tasks.rpmbuild-ppc64le.results.rpmbuild-artifact)
         - name: script-environment-image
           value: $(params.script-environment-image)
+        - name: purl-rpm-namespace
+          value: $(params.purl-rpm-namespace)
       runAfter:
         - rpmbuild-s390x
         - rpmbuild-x86-64

--- a/task/import-to-quay.yaml
+++ b/task/import-to-quay.yaml
@@ -52,6 +52,10 @@ spec:
     - description: RPM Build environment OCI image to run scripts in
       name: script-environment-image
       type: string
+    - name: purl-rpm-namespace
+      description: PURL namespace for RPM packages in the generated SBOM (e.g., fedora, redhat)
+      type: string
+      default: "fedora"
   results:
     - name: IMAGE_URL
       description: Location of build artifact
@@ -145,6 +149,9 @@ spec:
         #!/bin/bash
         export PS4='+ $(date "+%Y-%m-%d %H:%M:%S") '
         set -x
+        # Configure PURL RPM namespace for SBOM generation
+        mkdir -p /etc/rpmbuild_sbom
+        echo '{"purl_rpm_namespace": "$(params.purl-rpm-namespace)"}' > /etc/rpmbuild_sbom/config.json
         # list dirs
         find . | sort
         # Create empty SPDX doc as placeholder for --syft-sbom (to be removed later)

--- a/task/import-to-quay.yaml
+++ b/task/import-to-quay.yaml
@@ -150,13 +150,12 @@ spec:
         export PS4='+ $(date "+%Y-%m-%d %H:%M:%S") '
         set -x
         # Configure PURL RPM namespace for SBOM generation
-        mkdir -p /etc/rpmbuild_sbom
-        echo '{"purl_rpm_namespace": "$(params.purl-rpm-namespace)"}' > /etc/rpmbuild_sbom/config.json
+        echo '{"purl_rpm_namespace": "$(params.purl-rpm-namespace)"}' > rpmbuild_sbom_config.json
         # list dirs
         find . | sort
         # Create empty SPDX doc as placeholder for --syft-sbom (to be removed later)
         echo '{"spdxVersion":"SPDX-2.3","packages":[],"files":[],"relationships":[]}' > syft-sbom.json
-        ARGS=(--rpm-dir . --syft-sbom syft-sbom.json --sbom-merged sbom-merged.json)
+        ARGS=(--rpm-dir . --syft-sbom syft-sbom.json --sbom-merged sbom-merged.json --config rpmbuild_sbom_config.json)
         if [ -f ancestors.json ]; then
           ARGS+=(--source-data ancestors.json)
         else


### PR DESCRIPTION
## Summary
- Adds a `purl-rpm-namespace` pipeline parameter (default: `fedora`) that controls the PURL namespace used in generated SBOMs
- The parameter flows from the pipeline to the `import-to-quay` task, which writes it to `/etc/rpmbuild_sbom/config.json` for `merge_sboms.py` to consume
- Enables deployments like Hummingbird to set the namespace to `redhat` instead of the hardcoded `fedora`

## Test plan
- [ ] Run pipeline with default parameters and verify SBOMs contain `pkg:rpm/fedora/...` PURLs
- [ ] Run pipeline with `purl-rpm-namespace: redhat` and verify SBOMs contain `pkg:rpm/redhat/...` PURLs
- [ ] Verify the `show-sbom` step output reflects the configured namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)