### PR TITLE
feat: add pulp-target-arch-repo pipeline parameter

### DIFF
--- a/pipeline/build-rpm-package.yaml
+++ b/pipeline/build-rpm-package.yaml
@@ -158,6 +158,10 @@ spec:
       description: Mock chroot name from mock-core-configs (e.g. fedora-rawhide-@ARCH@, fedora-44-@ARCH@)
       type: string
       default: fedora-rawhide-@ARCH@
+    - name: pulp-target-arch-repo
+      description: Use per-architecture Pulp repositories for stable DNF-consumable URLs
+      type: string
+      default: "false"
   results:
     - description: ""
       name: CHAINS-GIT_URL
@@ -769,6 +773,8 @@ spec:
           value: $(params.script-environment-image)
         - name: purl-rpm-namespace
           value: $(params.purl-rpm-namespace)
+        - name: pulp-target-arch-repo
+          value: $(params.pulp-target-arch-repo)
       runAfter:
         - rpmbuild-s390
         - rpmbuild-s390x

--- a/task/import-to-quay.yaml
+++ b/task/import-to-quay.yaml
@@ -59,6 +59,10 @@ spec:
       description: PURL namespace for RPM packages in the generated SBOM (e.g., fedora, redhat)
       type: string
       default: "fedora"
+    - name: pulp-target-arch-repo
+      description: Use per-architecture Pulp repositories instead of per-build repos
+      type: string
+      default: "false"
   results:
     - name: IMAGE_URL
       description: Location of build artifact
@@ -191,14 +195,20 @@ spec:
         : > "$(results.PULP-IMAGE_DIGEST.path)"
 
         if [ -f /pulp-access/cli.toml ]; then
-          pulp-tool --config /pulp-access/cli.toml \
-            --build-id "$(params.pipelinerun-id)" \
-            --namespace "$(context.taskRun.namespace)" \
-            upload \
-            --parent-package "$(params.package-name)" \
-            --rpm-path "/var/workdir/results" \
-            --sbom-path "/var/workdir/results/oras-staging/sbom-merged.json" \
+          PULP_ARGS=(
+            pulp-tool --config /pulp-access/cli.toml
+            --build-id "$(params.pipelinerun-id)"
+            --namespace "$(context.taskRun.namespace)"
+            upload
+            --parent-package "$(params.package-name)"
+            --rpm-path "/var/workdir/results"
+            --sbom-path "/var/workdir/results/oras-staging/sbom-merged.json"
             --artifact-results "$(results.PULP-IMAGE_URL.path)","$(results.PULP-IMAGE_DIGEST.path)"
+          )
+          if [ "$(params.pulp-target-arch-repo)" = "true" ]; then
+            PULP_ARGS+=(--target-arch-repo)
+          fi
+          "${PULP_ARGS[@]}"
         else
           echo "Pulp config file does not exist; skipping push and writing empty Pulp result files"
         fi


### PR DESCRIPTION
## Summary
- Adds an optional `pulp-target-arch-repo` pipeline parameter (default `"false"`) that flows from the pipeline to the `import-to-quay` task
- When set to `"true"`, passes `--target-arch-repo` to `pulp-tool`, which uploads RPMs to stable per-architecture Pulp repositories (e.g. `/api/pulp-content/{domain}/x86_64/Packages/...`) instead of per-build paths
- Enables using Pulp RPM URLs directly in DNF repo configuration files

## Dependencies
- Depends on #239 (expose `chroot` as pipeline parameter)

## Test plan
- [ ] Verify default behavior (`"false"`) — RPMs upload to per-build Pulp repos as before
- [ ] Set `pulp-target-arch-repo: "true"` in PipelineRun params and verify RPMs land at per-arch paths
- [ ] Confirm the stable per-arch repo URL is usable as a DNF `baseurl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)