### PR TITLE
feat: expose chroot as pipeline parameter

### DIFF
--- a/.tekton/libecpg-pull-request.yaml
+++ b/.tekton/libecpg-pull-request.yaml
@@ -43,6 +43,8 @@ spec:
       value: quay.io/redhat-user-workloads/rpm-build-pipeline-tenant/ci-for-pipeline:on-pr-libecpg-{{ revision }}
     - name: chroot
       value: fedora-44-@ARCH@
+    - name: target-distribution
+      value: fedora-44
     - name: build-architectures
       value:
         - x86_64

--- a/.tekton/libecpg-pull-request.yaml
+++ b/.tekton/libecpg-pull-request.yaml
@@ -41,6 +41,8 @@ spec:
       value: -rpmbuild-pipeline
     - name: ociStorage
       value: quay.io/redhat-user-workloads/rpm-build-pipeline-tenant/ci-for-pipeline:on-pr-libecpg-{{ revision }}
+    - name: chroot
+      value: fedora-44-@ARCH@
     - name: build-architectures
       value:
         - x86_64

--- a/.tekton/libecpg-pull-request.yaml
+++ b/.tekton/libecpg-pull-request.yaml
@@ -42,9 +42,9 @@ spec:
     - name: ociStorage
       value: quay.io/redhat-user-workloads/rpm-build-pipeline-tenant/ci-for-pipeline:on-pr-libecpg-{{ revision }}
     - name: chroot
-      value: fedora-44-@ARCH@
+      value: fedora-rawhide-@ARCH@
     - name: target-distribution
-      value: fedora-44
+      value: fedora-rawhide
     - name: build-architectures
       value:
         - x86_64

--- a/pipeline/build-rpm-package.yaml
+++ b/pipeline/build-rpm-package.yaml
@@ -154,6 +154,10 @@ spec:
       description: PURL namespace for RPM packages in the generated SBOM (e.g., fedora, redhat)
       type: string
       default: "fedora"
+    - name: chroot
+      description: Mock chroot name from mock-core-configs (e.g. fedora-rawhide-@ARCH@, fedora-44-@ARCH@)
+      type: string
+      default: fedora-rawhide-@ARCH@
   results:
     - description: ""
       name: CHAINS-GIT_URL
@@ -300,7 +304,7 @@ spec:
         - name: mock-config-template-filename-in-sources
           value: $(params.mock-config-template-filename-in-sources)
         - name: chroot
-          value: fedora-rawhide-@ARCH@
+          value: $(params.chroot)
         - name: ociArtifactExpiresAfter
           value: $(params.ociArtifactExpiresAfter)
     - name: calculate-deps-x86-64


### PR DESCRIPTION
## Summary
- Expose the mock `chroot` name as a configurable pipeline parameter instead of hardcoding `fedora-rawhide-@ARCH@`
- Defaults to `fedora-rawhide-@ARCH@` so existing behavior is unchanged
- Set the hermetic CI test (`libecpg-pull-request`) to use `fedora-44-@ARCH@` to avoid transient Fedora rawhide CDN download failures

## Test plan
- [x] Verify hermetic CI test passes with `fedora-44-@ARCH@`
- [x] Verify other CI tests still pass (they use default rawhide or custom mock.cfg)
- [ ] Verify production pipelines are unaffected (default value unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)