### PR TITLE
fix: move SBOM_BLOB_URL result to merge-syft-sbom step to prevent truncation

### DIFF
--- a/task/import-to-quay.yaml
+++ b/task/import-to-quay.yaml
@@ -167,6 +167,20 @@ spec:
           echo "WARNING: buildroot_rpms.json not found in oras-staging, skipping buildroot data in SBOM" >&2
         fi
         merge_sboms.py "${ARGS[@]}"
+
+        # Write SBOM_BLOB_URL result here rather than in a later step to avoid
+        # Tekton termination message truncation. Each step's entrypoint includes
+        # ALL accumulated results in its termination message. When the last step
+        # carries too many results, the message exceeds the container runtime's
+        # size limit and is truncated, producing invalid JSON that the Tekton
+        # controller cannot parse. Any result unique to the last step is then
+        # silently lost. By writing SBOM_BLOB_URL here (before the Pulp results
+        # inflate the message), it is captured in this step's termination message
+        # which stays well within the limit.
+        IMAGE_URL=$(cat $(results.IMAGE_URL.path))
+        REPO=${IMAGE_URL%:*}
+        SBOM_DIGEST=$(sha256sum sbom-merged.json | awk '{ print $1 }')
+        echo -n "${REPO}@sha256:${SBOM_DIGEST}" | tee $(results.SBOM_BLOB_URL.path)
     - name: show-sbom
       image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
       workingDir: /var/workdir/results/oras-staging
@@ -207,18 +221,6 @@ spec:
          --type spdx \
          $(cat $(results.IMAGE_URL.path))@$(cat $(results.IMAGE_DIGEST.path))
       workingDir: /var/workdir
-    - name: report-sbom-url
-      image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
-      workingDir: /var/workdir/results/oras-staging
-      script: |
-        #!/usr/bin/env bash
-        set -e
-        IMAGE_URL=$(cat $(results.IMAGE_URL.path))
-        REPO=${IMAGE_URL%:*}
-        echo "Found that ${REPO} is the repository for ${IMAGE_URL}"
-        SBOM_DIGEST=$(sha256sum sbom-merged.json | awk '{ print $1 }')
-        echo "Found that ${SBOM_DIGEST} is the SBOM digest"
-        echo -n "${REPO}@sha256:${SBOM_DIGEST}" | tee $(results.SBOM_BLOB_URL.path)
   volumes:
     - name: pulp-access-credentials
       secret:

--- a/task/import-to-quay.yaml
+++ b/task/import-to-quay.yaml
@@ -177,6 +177,10 @@ spec:
         # silently lost. By writing SBOM_BLOB_URL here (before the Pulp results
         # inflate the message), it is captured in this step's termination message
         # which stays well within the limit.
+        if [ ! -f sbom-merged.json ]; then
+          echo "Error: sbom-merged.json was not generated." >&2
+          exit 1
+        fi
         IMAGE_URL=$(cat $(results.IMAGE_URL.path))
         REPO=${IMAGE_URL%:*}
         SBOM_DIGEST=$(sha256sum sbom-merged.json | awk '{ print $1 }')


### PR DESCRIPTION
## Summary

Fixes a bug where the `SBOM_BLOB_URL` pipeline result is silently lost, causing every PipelineRun to fail with:

```
invalid pipelineresults [SBOM_BLOB_URL], the referenced results don't exist
```

### Root cause

The cluster uses `results-from: termination-message` (the Tekton default). Each step's Tekton entrypoint reads **all** result files from `/tekton/results/` and serializes them into the container's termination message. As results accumulate across the 12 steps in `import-to-quay`, later steps carry progressively larger messages.

When the `pulp-access` secret is present in the namespace, `pulp-tool` writes a ~185-character URL to `PULP-IMAGE_URL`, inflating every subsequent step's termination message by ~264 bytes. The final step (`report-sbom-url`) accumulates all 6 task results plus Tekton's internal `StartedAt` marker, producing a message that exceeds the container runtime's size limit and is **truncated** — making the JSON unparseable.

The Tekton controller recovers 5 of 6 results from earlier steps' valid termination messages, but `SBOM_BLOB_URL` (uniquely written by the last step) is lost:

| Step | Results | Message size | Valid? |
|------|---------|-------------|--------|
| push-to-quay-select-auth | 3 (IMAGE_URL, IMAGE_DIGEST, NVR) | 374 bytes | ✅ |
| push-to-pulp-select-auth | 5 (+PULP results) | 638 bytes | ✅ |
| report-sbom-url | 6 (+SBOM_BLOB_URL) + StartedAt | 877 bytes | ❌ Truncated |

### Fix

- Compute and write `SBOM_BLOB_URL` at the end of the `merge-syft-sbom` step, immediately after the SBOM is generated
- Delete the now-redundant `report-sbom-url` step

This ensures `SBOM_BLOB_URL` appears in `merge-syft-sbom`'s termination message (~596 bytes), well within the limit. The last step (`upload-sbom-to-quay`) writes no new results, so its message stays at ~638 bytes.

Ref: [HUM-2312](https://redhat.atlassian.net/browse/HUM-2312)

## Test plan

- [ ] PipelineRun completes without `invalid pipelineresults [SBOM_BLOB_URL]` error
- [ ] `SBOM_BLOB_URL` result is present in the TaskRun `.status.results`
- [ ] SBOM content is unchanged (same sha256 digest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[HUM-2312]: https://redhat.atlassian.net/browse/HUM-2312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ