### PR TITLE
add `imagePullPolicy: IfNotPresent` to the stepTemplate in Task YAMLs

### DIFF
--- a/task/calculate-deps.yaml
+++ b/task/calculate-deps.yaml
@@ -49,6 +49,7 @@ spec:
       description: The Trusted Artifact URI pointing to the artifact with the result of the deps calculation.
       type: string
   stepTemplate:
+    imagePullPolicy: IfNotPresent
     volumeMounts:
       - mountPath: /var/workdir
         name: workdir

--- a/task/check-noarch.yaml
+++ b/task/check-noarch.yaml
@@ -28,6 +28,7 @@ spec:
       name: script-environment-image
       type: string
   stepTemplate:
+    imagePullPolicy: IfNotPresent
     volumeMounts:
       - mountPath: /var/workdir
         name: workdir

--- a/task/import-to-quay.yaml
+++ b/task/import-to-quay.yaml
@@ -71,6 +71,7 @@ spec:
     - name: PULP-IMAGE_DIGEST
       description: Pulp build artifact digest
   stepTemplate:
+    imagePullPolicy: IfNotPresent
     volumeMounts:
       - mountPath: /var/workdir/results
         name: workdir

--- a/task/prepare-mock-config.yaml
+++ b/task/prepare-mock-config.yaml
@@ -36,6 +36,7 @@ spec:
       description: Mock configuration template file (trusted-artifact, string content)
       type: string
   stepTemplate:
+    imagePullPolicy: IfNotPresent
     volumeMounts:
       - mountPath: /var/workdir
         name: workdir

--- a/task/process-sources.yaml
+++ b/task/process-sources.yaml
@@ -97,6 +97,7 @@ spec:
         build-i686:
           type: string
   stepTemplate:
+    imagePullPolicy: IfNotPresent
     volumeMounts:
       - mountPath: /var/workdir
         name: workdir

--- a/task/rpmbuild.yaml
+++ b/task/rpmbuild.yaml
@@ -59,6 +59,7 @@ spec:
   # we have to configure per-Task timeout in the Pipeline
   # file.
   stepTemplate:
+    imagePullPolicy: IfNotPresent
     volumeMounts:
       - mountPath: /var/workdir
         name: workdir


### PR DESCRIPTION
Add `imagePullPolicy: IfNotPresent` to the stepTemplate to define a common container configuration
that applies to all steps in the Task, instead of having to set it for each step individually.

In the recent 200-concurrent RPM build pipeline test done on stg-rh01 cluster, 9 builds failed with the error TaskRunImagePullFailed. Upon reviewing the status of the failed PipelineRuns and TaskRuns, the same error was observed across all failed builds.

`the step "use-trusted-artifact-results" in TaskRun "example-rok-libecpg-on-pull-request-xpxxz-rpmbuild-ppc64le" failed to pull the image "". The pod errored with the message: "Back-off pulling image "quay.io/konflux-ci/build-trusted-artifacts@sha256:90a188e90bf8f33cf93016bcfdfd0a3a9e7df6ff13691f001a0ed4f014060e2e": ErrImagePull: pull QPS exceeded."`

The Pipelines team identified that the errors were caused by container images being downloaded repeatedly during pipeline execution. To prevent unnecessary image pulls, `imagePullPolicy: IfNotPresent` was added to all pipeline steps so images are only pulled when not already available locally.

While reviewing the image URLs in the `rpmbuild-pipeline` repository, I noticed that most images are specified using both the `latest` tag and a fixed image digest. Although Kubernetes ultimately pulls the image using the digest, the presence of the `latest` tag causes Kubernetes to automatically set the image pull policy to `Always`. As a result, images are pulled on every pipeline run, even when the same image is already available locally.

Since these errors are related to Kubernetes and Pipelines in general, and are not specific to the RPM build pipeline or Konflux controllers, we reproduced the issue using a simple pipeline. This allowed us to validate the proposed fix without requiring the full RPM build pipeline setup.

After applying `imagePullPolicy: IfNotPresent`, showed that images were no longer downloaded repeatedly for every task. Instead, they were reused when already available, which significantly reduced image pulls. Overall, this change reduced image pull failures under high concurrency and improved cluster stability.

Please take a look at this report for more information - [taskRunImagePullFailure-pull-QPS-exceeded.md](https://github.com/mcharanrm/tekton-resolver-benchmarks/blob/master/pull-QPS-exceeded.md)