### PR TITLE
Drop latest tag from build-trusted-artifacts

### DIFF
--- a/task/calculate-deps.yaml
+++ b/task/calculate-deps.yaml
@@ -55,12 +55,12 @@ spec:
         name: workdir
   steps:
     - name: use-trusted-artifact
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
       args:
         - use
         - $(params.dependencies-artifact)=/var/workdir/source
     - name: use-trusted-artifact-mock-config
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
       args:
         - use
         - $(params.mock-config-template-file)=/var/workdir/mock-config
@@ -193,7 +193,7 @@ spec:
         requests:
           ephemeral-storage: 5Gi
     - name: create-trusted-artifact
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
       args:
         - create
         - --store

--- a/task/check-noarch.yaml
+++ b/task/check-noarch.yaml
@@ -37,17 +37,17 @@ spec:
         name: workdir
   steps:
     - name: use-trusted-artifact-i686
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:90a188e90bf8f33cf93016bcfdfd0a3a9e7df6ff13691f001a0ed4f014060e2e
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:90a188e90bf8f33cf93016bcfdfd0a3a9e7df6ff13691f001a0ed4f014060e2e
       args:
         - use
         - $(params.i686-artifact)=/var/workdir/results
     - name: use-trusted-artifact-x86-64
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
       args:
         - use
         - $(params.x86_64-artifact)=/var/workdir/results
     - name: use-trusted-artifact-aarch64
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
       args:
         - use
         - $(params.aarch64-artifact)=/var/workdir/results
@@ -57,12 +57,12 @@ spec:
         - use
         - $(params.s390-artifact)=/var/workdir/results
     - name: use-trusted-artifact-s390x
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
       args:
         - use
         - $(params.s390x-artifact)=/var/workdir/results
     - name: use-trusted-artifact-ppc64le
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
       args:
         - use
         - $(params.ppc64le-artifact)=/var/workdir/results

--- a/task/import-to-quay.yaml
+++ b/task/import-to-quay.yaml
@@ -84,12 +84,12 @@ spec:
         name: workdir
   steps:
     - name: use-trusted-artifact-x86-64
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
       args:
         - use
         - $(params.x86_64-artifact)=/var/workdir/results
     - name: use-trusted-artifact-aarch64
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
       args:
         - use
         - $(params.aarch64-artifact)=/var/workdir/results
@@ -99,17 +99,17 @@ spec:
         - use
         - $(params.s390-artifact)=/var/workdir/results
     - name: use-trusted-artifact-s390x
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
       args:
         - use
         - $(params.s390x-artifact)=/var/workdir/results
     - name: use-trusted-artifact-ppc64le
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
       args:
         - use
         - $(params.ppc64le-artifact)=/var/workdir/results
     - name: use-trusted-artifact-i686
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
       args:
         - use
         - $(params.i686-artifact)=/var/workdir/results

--- a/task/prepare-mock-config.yaml
+++ b/task/prepare-mock-config.yaml
@@ -42,7 +42,7 @@ spec:
         name: workdir
   steps:
     - name: use-trusted-artifact
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
       args:
         - use
         - $(params.source-artifact)=/var/workdir/source
@@ -71,7 +71,7 @@ spec:
         # present the file in logs
         cat "$mock_config_template"
     - name: create-trusted-artifact-mock-config
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
       args:
         - create
         - --store

--- a/task/process-sources.yaml
+++ b/task/process-sources.yaml
@@ -110,7 +110,7 @@ spec:
         value: $(params.monorepo-subdir)
   steps:
     - name: use-trusted-artifact
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
       args:
         - use
         - $(params.source-artifact)=/var/workdir/source
@@ -172,7 +172,7 @@ spec:
           python3 /usr/local/bin/select_architectures.py "$@" --target-distribution "$(params.target-distribution)" --results-file "$(results.skip-mpc-tasks.path)" --workdir "${working_dir}"
         fi
     - name: create-trusted-artifact
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
       args:
         - create
         - --store

--- a/task/rpmbuild.yaml
+++ b/task/rpmbuild.yaml
@@ -65,17 +65,17 @@ spec:
         name: workdir
   steps:
     - name: use-trusted-artifact-source
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
       args:
         - use
         - $(params.dependencies-artifact)=/var/workdir/source
     - name: use-trusted-artifact-results
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
       args:
         - use
         - $(params.calculation-artifact)=/var/workdir/results
     - name: use-trusted-artifact-mock-config
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
       args:
         - use
         - $(params.mock-config-template-file)=/var/workdir/mock-config
@@ -307,7 +307,7 @@ spec:
           syft "$rpm_dir" -o spdx-json > "results/$(params.arch)/$rpm_nvra.sbom.json"
         done
     - name: create-trusted-artifact
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
       args:
         - create
         - --store


### PR DESCRIPTION
Improves caching in openshift + better renovate behaviour