### PR TITLE
Configure snapshot expiration

### DIFF
--- a/pipeline/build-rpm-package.yaml
+++ b/pipeline/build-rpm-package.yaml
@@ -747,6 +747,8 @@ spec:
       params:
         - name: ociStorage
           value: $(params.ociStorage).built-artifacts
+        - name: ociArtifactExpiresAfter
+          value: $(params.ociArtifactExpiresAfter)
         - name: git-url
           value: $(params.git-url)
         - name: revision

--- a/task/import-to-quay.yaml
+++ b/task/import-to-quay.yaml
@@ -17,6 +17,8 @@ spec:
       type: string
     - name: ociStorage
       type: string
+    - name: ociArtifactExpiresAfter
+      type: string
     - description: The name of the package we build
       name: package-name
       type: string
@@ -148,7 +150,7 @@ spec:
         oras push \
              --registry-config "$HOME/auth.json" \
              --artifact-type application/vnd.rpm.build.v0 \
-             --annotation quay.expires-after=14d \
+             --annotation quay.expires-after=$(params.ociArtifactExpiresAfter)\
              $IMAGE_URL \
              `cat ../oras-push-list.txt` | tee /tmp/oras.log
 

--- a/task/import-to-quay.yaml
+++ b/task/import-to-quay.yaml
@@ -18,6 +18,7 @@ spec:
     - name: ociStorage
       type: string
     - name: ociArtifactExpiresAfter
+      description: How long Trusted Artifacts should be retained
       type: string
     - description: The name of the package we build
       name: package-name
@@ -150,7 +151,7 @@ spec:
         oras push \
              --registry-config "$HOME/auth.json" \
              --artifact-type application/vnd.rpm.build.v0 \
-             --annotation quay.expires-after=$(params.ociArtifactExpiresAfter)\
+             --annotation quay.expires-after=$(params.ociArtifactExpiresAfter) \
              $IMAGE_URL \
              `cat ../oras-push-list.txt` | tee /tmp/oras.log
 


### PR DESCRIPTION
We have ociArtifactExpiration but it doesn't have impact on snapshots which are annotated on controller level, not the pipeline.

https://github.com/konflux-ci/build-service/blob/177969c7a71c407e96f5e6e12ae40bda12cb528b/internal/controller/component_build_controller_pipeline.go#L478-L484